### PR TITLE
Fix Spotify library endpoint (Feb 2026 API change) + bump to v1.8.1

### DIFF
--- a/spotify_skip_recently_played_song.py
+++ b/spotify_skip_recently_played_song.py
@@ -44,7 +44,7 @@ import threading
 
 import builtins # builtins needed to print timestamps with every print
 
-APP_VERSION = "v1.8.0"
+APP_VERSION = "v1.8.1"
 
 # -------------------------------------------------------------
 # SETTINGS FROM config.ini


### PR DESCRIPTION
- migrate from /v1/me/tracks/contains to /v1/me/library/contains
- required due to February 2026 Spotify Web API changes
- bump version to v1.8.1