### PR TITLE
Add Loved Sync: Spotify Liked vs Last.fm Loved (v3.7.0-1)

### DIFF
--- a/cloud/.env.example
+++ b/cloud/.env.example
@@ -5,6 +5,8 @@ SPOTIFY_CLIENT_SECRET=
 # Last.fm credentials (from https://www.last.fm/api/account/create)
 LASTFM_USERNAME=
 LASTFM_API_KEY=
+# API secret is required for write methods (track.love) used by Loved Sync
+LASTFM_API_SECRET=
 
 # Secret key for session signing (min 16 chars, generate with: python -c "import secrets; print(secrets.token_urlsafe(32))")
 SECRET_KEY=

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.7.0-4"
+APP_VERSION = "v3.7.0"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.7.0-3"
+APP_VERSION = "v3.7.0-4"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.7.0-1"
+APP_VERSION = "v3.7.0-2"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.7.0-2"
+APP_VERSION = "v3.7.0-3"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.6.5"
+APP_VERSION = "v3.7.0-1"

--- a/cloud/app/config.py
+++ b/cloud/app/config.py
@@ -76,6 +76,10 @@ def get_lastfm_api_key() -> str:
     return os.environ.get("LASTFM_API_KEY", "")
 
 
+def get_lastfm_api_secret() -> str:
+    return os.environ.get("LASTFM_API_SECRET", "")
+
+
 def get_secret_key() -> str:
     key = os.environ.get("SECRET_KEY", "")
     if not key or len(key) < 32:

--- a/cloud/app/database.py
+++ b/cloud/app/database.py
@@ -98,6 +98,18 @@ CREATE TABLE IF NOT EXISTS mapping_fail_dismissals (
     dismissed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE IF NOT EXISTS lastfm_auth (
+    id            INTEGER PRIMARY KEY CHECK (id = 1),
+    session_key   TEXT NOT NULL,
+    username      TEXT NOT NULL DEFAULT '',
+    authorized_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS loved_sync_ignored (
+    track_id    TEXT PRIMARY KEY,
+    ignored_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE INDEX IF NOT EXISTS idx_track_events_timestamp ON track_events(timestamp);
 CREATE INDEX IF NOT EXISTS idx_logs_timestamp ON logs(timestamp);
 """
@@ -227,6 +239,28 @@ async def get_track_alias(track_id: str, artist: str = "", spotify_name: str = "
                 return row["lastfm_name"]
 
         return None
+    finally:
+        await db.close()
+
+
+async def get_all_track_aliases() -> dict:
+    """Return all aliases as two lookup dicts:
+    {by_id: {track_id: lastfm_name}, by_artist_name: {(artist, spotify_name): lastfm_name}}.
+
+    Use this when batch-resolving many tracks instead of N x get_track_alias() calls.
+    """
+    db = await get_db()
+    try:
+        cursor = await db.execute("SELECT track_id, artist, spotify_name, lastfm_name FROM track_aliases")
+        rows = await cursor.fetchall()
+        by_id = {}
+        by_artist_name = {}
+        for row in rows:
+            if row["track_id"]:
+                by_id[row["track_id"]] = row["lastfm_name"]
+            else:
+                by_artist_name[(row["artist"], row["spotify_name"])] = row["lastfm_name"]
+        return {"by_id": by_id, "by_artist_name": by_artist_name}
     finally:
         await db.close()
 
@@ -976,6 +1010,87 @@ async def get_mapping_fail_candidates(skip_window_days: int) -> list[dict]:
         )
         rows = await cursor.fetchall()
         return [dict(row) for row in rows]
+    finally:
+        await db.close()
+
+
+# ── Last.fm session key (encrypted) ──────────────────────────────
+
+
+async def get_lastfm_session() -> dict | None:
+    """Return decrypted Last.fm session info, or None if not authorized."""
+    db = await get_db()
+    try:
+        row = await (
+            await db.execute("SELECT session_key, username, authorized_at FROM lastfm_auth WHERE id = 1")
+        ).fetchone()
+        if not row or not row["session_key"]:
+            return None
+        return {
+            "session_key": decrypt(row["session_key"]),
+            "username": row["username"] or "",
+            "authorized_at": row["authorized_at"],
+        }
+    finally:
+        await db.close()
+
+
+async def save_lastfm_session(session_key: str, username: str = ""):
+    enc = encrypt(session_key)
+    db = await get_db()
+    try:
+        await db.execute(
+            """INSERT INTO lastfm_auth (id, session_key, username, authorized_at)
+               VALUES (1, ?, ?, CURRENT_TIMESTAMP)
+               ON CONFLICT(id) DO UPDATE SET
+                   session_key = ?, username = ?, authorized_at = CURRENT_TIMESTAMP""",
+            (enc, username, enc, username),
+        )
+        await db.commit()
+    finally:
+        await db.close()
+
+
+async def clear_lastfm_session():
+    db = await get_db()
+    try:
+        await db.execute("DELETE FROM lastfm_auth")
+        await db.commit()
+    finally:
+        await db.close()
+
+
+# ── Loved-sync ignore list ───────────────────────────────────────
+
+
+async def get_loved_sync_ignored() -> set[str]:
+    """Return Spotify track_ids hidden from the 'needs love' list."""
+    db = await get_db()
+    try:
+        cursor = await db.execute("SELECT track_id FROM loved_sync_ignored")
+        rows = await cursor.fetchall()
+        return {row["track_id"] for row in rows}
+    finally:
+        await db.close()
+
+
+async def add_loved_sync_ignore(track_id: str):
+    db = await get_db()
+    try:
+        await db.execute(
+            "INSERT OR IGNORE INTO loved_sync_ignored (track_id) VALUES (?)",
+            (track_id,),
+        )
+        await db.commit()
+    finally:
+        await db.close()
+
+
+async def remove_loved_sync_ignore(track_id: str):
+    db = await get_db()
+    try:
+        await db.execute("DELETE FROM loved_sync_ignored WHERE track_id = ?", (track_id,))
+        await db.commit()
     finally:
         await db.close()
 

--- a/cloud/app/lastfm_api.py
+++ b/cloud/app/lastfm_api.py
@@ -3,18 +3,38 @@ Last.fm API wrapper — async version.
 Nearly verbatim port from desktop app.
 """
 
+import hashlib
 import logging
 from datetime import datetime, timezone
 
 import httpx
 
-from app.config import get_lastfm_api_key, get_lastfm_username
+from app.config import get_lastfm_api_key, get_lastfm_api_secret, get_lastfm_username
 from app.spotify_api import CredentialError
 
 logger = logging.getLogger(__name__)
 
+LASTFM_API_URL = "https://ws.audioscrobbler.com/2.0/"
+
 # Sentinel: returned when Last.fm could not be reached (distinct from None = no scrobbles)
 LASTFM_ERROR = "LASTFM_ERROR"
+
+
+class LastfmAuthError(Exception):
+    """Raised when Last.fm auth/signing operations fail."""
+
+
+def _sign(params: dict) -> str:
+    """Compute api_sig: md5(concat of sorted-key params + api_secret).
+
+    Per Last.fm docs: omit `format` and `callback` from the signature input.
+    """
+    secret = get_lastfm_api_secret()
+    if not secret:
+        raise LastfmAuthError("LASTFM_API_SECRET is not set.")
+    keys = sorted(k for k in params if k not in ("format", "callback"))
+    raw = "".join(f"{k}{params[k]}" for k in keys) + secret
+    return hashlib.md5(raw.encode("utf-8")).hexdigest()
 
 
 async def _lookup_scrobbles(artist: str, track: str) -> datetime | str | None:
@@ -103,3 +123,159 @@ async def get_last_play_date(artist: str, track: str, track_id: str = "") -> dat
         return await _lookup_scrobbles(artist, alias)
 
     return await _lookup_scrobbles(artist, track)
+
+
+# ── Loved tracks (read) ──────────────────────────────────────────
+
+
+async def get_loved_tracks(username: str = "") -> list[dict] | str:
+    """Return all loved tracks for the user (paginated). Returns LASTFM_ERROR on failure.
+
+    Each entry: {"artist": str, "name": str, "uts": int|None}.
+    """
+    user = username or get_lastfm_username()
+    if not user:
+        return []
+
+    results: list[dict] = []
+    page = 1
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            while True:
+                r = await client.get(
+                    LASTFM_API_URL,
+                    params={
+                        "method": "user.getlovedtracks",
+                        "user": user,
+                        "api_key": get_lastfm_api_key(),
+                        "format": "json",
+                        "limit": 200,
+                        "page": page,
+                    },
+                )
+                if r.status_code != 200:
+                    logger.warning("[Last.fm] getLovedTracks status %d: %s", r.status_code, r.text[:200])
+                    return LASTFM_ERROR
+                data = r.json() or {}
+                loved = data.get("lovedtracks", {})
+                tracks = loved.get("track", [])
+                if isinstance(tracks, dict):
+                    tracks = [tracks]
+                for t in tracks:
+                    artist_obj = t.get("artist") or {}
+                    artist_name = artist_obj.get("name") if isinstance(artist_obj, dict) else str(artist_obj)
+                    name = t.get("name", "")
+                    date_obj = t.get("date") or {}
+                    uts_raw = date_obj.get("uts") if isinstance(date_obj, dict) else None
+                    try:
+                        uts = int(uts_raw) if uts_raw else None
+                    except (ValueError, TypeError):
+                        uts = None
+                    if artist_name and name:
+                        results.append({"artist": artist_name, "name": name, "uts": uts})
+
+                attr = loved.get("@attr", {})
+                try:
+                    total_pages = int(attr.get("totalPages", 1))
+                except (ValueError, TypeError):
+                    total_pages = 1
+                if page >= total_pages:
+                    break
+                page += 1
+    except httpx.RequestError as e:
+        logger.warning("[Last.fm] Network error fetching loved tracks: %s", e)
+        return LASTFM_ERROR
+
+    return results
+
+
+# ── Authenticated session (write) ────────────────────────────────
+
+
+async def get_session_from_token(token: str) -> dict:
+    """Exchange a one-time auth token for a session key. Returns {key, name}.
+
+    Raises LastfmAuthError on any failure.
+    """
+    if not token:
+        raise LastfmAuthError("Missing token.")
+    api_key = get_lastfm_api_key()
+    if not api_key:
+        raise LastfmAuthError("LASTFM_API_KEY is not set.")
+
+    params = {"method": "auth.getSession", "api_key": api_key, "token": token}
+    params["api_sig"] = _sign(params)
+    params["format"] = "json"
+
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            r = await client.get(LASTFM_API_URL, params=params)
+    except httpx.RequestError as e:
+        raise LastfmAuthError(f"Network error: {e}")
+
+    try:
+        data = r.json()
+    except ValueError:
+        raise LastfmAuthError(f"Invalid response: {r.text[:200]}")
+
+    if r.status_code != 200 or "error" in data:
+        msg = data.get("message", r.text[:200]) if isinstance(data, dict) else r.text[:200]
+        raise LastfmAuthError(f"Last.fm rejected token: {msg}")
+
+    sess = (data or {}).get("session") or {}
+    key = sess.get("key")
+    name = sess.get("name", "")
+    if not key:
+        raise LastfmAuthError(f"No session key in response: {data}")
+    return {"key": key, "name": name}
+
+
+async def track_love(artist: str, track: str, session_key: str) -> tuple[bool, str]:
+    """Mark a track as Loved on Last.fm. Returns (ok, error_message).
+
+    Last.fm's track.love accepts arbitrary strings — the call succeeds even
+    when the (artist, track) pair isn't in their catalog. Treat that as
+    success; the love still attaches to the user's profile.
+    """
+    if not artist or not track:
+        return False, "Missing artist or track."
+    if not session_key:
+        return False, "Not authorized with Last.fm."
+    api_key = get_lastfm_api_key()
+    if not api_key:
+        return False, "LASTFM_API_KEY is not set."
+
+    params = {
+        "method": "track.love",
+        "artist": artist,
+        "track": track,
+        "api_key": api_key,
+        "sk": session_key,
+    }
+    try:
+        params["api_sig"] = _sign(params)
+    except LastfmAuthError as e:
+        return False, str(e)
+    params["format"] = "json"
+
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            r = await client.post(LASTFM_API_URL, data=params)
+    except httpx.RequestError as e:
+        return False, f"Network error: {e}"
+
+    if r.status_code != 200:
+        try:
+            err = r.json()
+            return False, err.get("message", f"HTTP {r.status_code}")
+        except ValueError:
+            return False, f"HTTP {r.status_code}: {r.text[:200]}"
+
+    try:
+        data = r.json()
+    except ValueError:
+        return True, ""
+
+    if isinstance(data, dict) and data.get("error"):
+        return False, data.get("message", "Unknown Last.fm error")
+    return True, ""

--- a/cloud/app/loved_sync.py
+++ b/cloud/app/loved_sync.py
@@ -1,0 +1,92 @@
+"""
+Loved Sync — diff Spotify Liked Songs against Last.fm Loved Tracks.
+
+Matching mirrors the worker's skip-check logic: each Spotify track is keyed by
+(artist, alias_or_track_name) where the alias comes from the track_aliases
+table (manual user-defined corrections). The same key is used to look up the
+Last.fm Loved set.
+"""
+
+from app.database import get_all_track_aliases, get_loved_sync_ignored
+from app.lastfm_api import LASTFM_ERROR, get_loved_tracks
+from app.spotify_api import CredentialError
+
+
+def _norm_key(artist: str, name: str) -> tuple[str, str]:
+    return (artist.strip().lower(), name.strip().lower())
+
+
+async def compute_diff(spotify_client, lastfm_username: str) -> dict:
+    """Compare Spotify Liked vs Last.fm Loved.
+
+    Returns:
+        {
+          "ok": bool,
+          "error": str | None,
+          "needs_love": [{id, artist, name, lastfm_name}],   # Liked, not Loved
+          "loved_not_liked": [{artist, name}],               # Loved, not Liked
+          "spotify_total": int,
+          "lastfm_total": int,
+          "ignored_count": int,
+        }
+    """
+    try:
+        spotify_liked = await spotify_client.get_all_saved_tracks()
+    except CredentialError as e:
+        return {"ok": False, "error": f"Spotify auth: {e}"}
+
+    loved = await get_loved_tracks(lastfm_username)
+    if loved == LASTFM_ERROR:
+        return {"ok": False, "error": "Could not reach Last.fm."}
+
+    ignored = await get_loved_sync_ignored()
+    aliases = await get_all_track_aliases()
+    by_id = aliases["by_id"]
+    by_artist_name = aliases["by_artist_name"]
+
+    # Resolve each Spotify track to its Last.fm-equivalent name (alias if any).
+    resolved = []
+    for sp in spotify_liked:
+        alias = by_id.get(sp["id"]) or by_artist_name.get((sp["artist"], sp["name"]))
+        lookup_name = alias or sp["name"]
+        resolved.append(
+            {
+                "id": sp["id"],
+                "artist": sp["artist"],
+                "name": sp["name"],
+                "lastfm_name": lookup_name,
+                "key": _norm_key(sp["artist"], lookup_name),
+            }
+        )
+
+    spotify_keys = {r["key"] for r in resolved}
+    lastfm_keys = {_norm_key(t["artist"], t["name"]) for t in loved}
+
+    needs_love = [
+        {
+            "id": r["id"],
+            "artist": r["artist"],
+            "name": r["name"],
+            "lastfm_name": r["lastfm_name"],
+        }
+        for r in resolved
+        if r["key"] not in lastfm_keys and r["id"] not in ignored
+    ]
+    needs_love.sort(key=lambda x: (x["artist"].lower(), x["name"].lower()))
+
+    loved_not_liked = [
+        {"artist": t["artist"], "name": t["name"]}
+        for t in loved
+        if _norm_key(t["artist"], t["name"]) not in spotify_keys
+    ]
+    loved_not_liked.sort(key=lambda x: (x["artist"].lower(), x["name"].lower()))
+
+    return {
+        "ok": True,
+        "error": None,
+        "needs_love": needs_love,
+        "loved_not_liked": loved_not_liked,
+        "spotify_total": len(spotify_liked),
+        "lastfm_total": len(loved),
+        "ignored_count": len(ignored),
+    }

--- a/cloud/app/loved_sync.py
+++ b/cloud/app/loved_sync.py
@@ -7,6 +7,9 @@ table (manual user-defined corrections). The same key is used to look up the
 Last.fm Loved set.
 """
 
+import re
+from difflib import SequenceMatcher
+
 from app.database import get_all_track_aliases, get_loved_sync_ignored
 from app.lastfm_api import LASTFM_ERROR, get_loved_tracks
 from app.spotify_api import CredentialError
@@ -14,6 +17,73 @@ from app.spotify_api import CredentialError
 
 def _norm_key(artist: str, name: str) -> tuple[str, str]:
     return (artist.strip().lower(), name.strip().lower())
+
+
+_PAREN_RE = re.compile(r"[\(\[].*?[\)\]]")
+_SUFFIX_RE = re.compile(r"\s*-\s*(remaster(ed)?|remix|version|edit|mix|anniversary|single|live|demo|instrumental).*", re.I)
+_FEAT_RE = re.compile(r"\s+(feat\.?|ft\.?)\s+.*", re.I)
+_PUNCT_RE = re.compile(r"[^\w\s]")
+_SPACE_RE = re.compile(r"\s+")
+
+
+def _normalize(s: str) -> str:
+    """Aggressive normalization for fuzzy matching only.
+
+    Used to score similarity — never as a match key. The actual alias still
+    stores the user-confirmed Last.fm name verbatim.
+    """
+    if not s:
+        return ""
+    s = s.lower().replace("&", "and")
+    s = s.replace("`", "'").replace("´", "'").replace("’", "'").replace("‘", "'")
+    s = _PAREN_RE.sub("", s)
+    s = _SUFFIX_RE.sub("", s)
+    s = _FEAT_RE.sub("", s)
+    s = _PUNCT_RE.sub(" ", s)
+    s = _SPACE_RE.sub(" ", s).strip()
+    return s
+
+
+def _similarity(a: str, b: str) -> float:
+    if not a or not b:
+        return 0.0
+    return SequenceMatcher(None, a, b).ratio()
+
+
+def find_candidates(spotify_track: dict, lastfm_pool: list[dict], top_n: int = 5) -> list[dict]:
+    """For one Spotify track, return up to top_n likely Last.fm matches.
+
+    Filters by normalized-artist similarity (>= 0.85) so cross-artist
+    suggestions are excluded. Track name similarity is weighted heavier in
+    the final score; entries below 0.5 name-similarity are dropped.
+    """
+    sp_artist = _normalize(spotify_track["artist"])
+    sp_name = _normalize(spotify_track["name"])
+    if not sp_artist or not sp_name:
+        return []
+
+    out = []
+    for lf in lastfm_pool:
+        lf_artist = _normalize(lf["artist"])
+        if not lf_artist:
+            continue
+        artist_sim = _similarity(sp_artist, lf_artist)
+        if artist_sim < 0.85:
+            continue
+        lf_name = _normalize(lf["name"])
+        name_sim = _similarity(sp_name, lf_name)
+        if name_sim < 0.5:
+            continue
+        score = name_sim * 0.8 + artist_sim * 0.2
+        out.append(
+            {
+                "artist": lf["artist"],
+                "name": lf["name"],
+                "score": round(score, 3),
+            }
+        )
+    out.sort(key=lambda c: c["score"], reverse=True)
+    return out[:top_n]
 
 
 async def compute_diff(spotify_client, lastfm_username: str) -> dict:
@@ -62,24 +132,32 @@ async def compute_diff(spotify_client, lastfm_username: str) -> dict:
     spotify_keys = {r["key"] for r in resolved}
     lastfm_keys = {_norm_key(t["artist"], t["name"]) for t in loved}
 
-    needs_love = [
-        {
-            "id": r["id"],
-            "artist": r["artist"],
-            "name": r["name"],
-            "lastfm_name": r["lastfm_name"],
-        }
-        for r in resolved
-        if r["key"] not in lastfm_keys and r["id"] not in ignored
-    ]
-    needs_love.sort(key=lambda x: (x["artist"].lower(), x["name"].lower()))
-
     loved_not_liked = [
         {"artist": t["artist"], "name": t["name"]}
         for t in loved
         if _norm_key(t["artist"], t["name"]) not in spotify_keys
     ]
     loved_not_liked.sort(key=lambda x: (x["artist"].lower(), x["name"].lower()))
+
+    needs_love = []
+    for r in resolved:
+        if r["key"] in lastfm_keys or r["id"] in ignored:
+            continue
+        candidates = find_candidates(
+            {"artist": r["artist"], "name": r["name"]},
+            loved_not_liked,
+            top_n=5,
+        )
+        needs_love.append(
+            {
+                "id": r["id"],
+                "artist": r["artist"],
+                "name": r["name"],
+                "lastfm_name": r["lastfm_name"],
+                "candidates": candidates,
+            }
+        )
+    needs_love.sort(key=lambda x: (x["artist"].lower(), x["name"].lower()))
 
     return {
         "ok": True,

--- a/cloud/app/main.py
+++ b/cloud/app/main.py
@@ -85,7 +85,7 @@ app.mount("/static", StaticFiles(directory=os.path.join(_app_dir, "static")), na
 templates = Jinja2Templates(directory=os.path.join(_app_dir, "templates"))
 
 # Include routers
-from app.routers import artists, auth, insights, logs, playback, rediscovery, settings
+from app.routers import artists, auth, insights, logs, loved_sync, playback, rediscovery, settings
 
 app.include_router(auth.router)
 app.include_router(playback.router)
@@ -94,6 +94,7 @@ app.include_router(artists.router)
 app.include_router(insights.router)
 app.include_router(logs.router)
 app.include_router(rediscovery.router)
+app.include_router(loved_sync.router)
 
 
 # ── Health check ─────────────────────────────────────────────────
@@ -159,6 +160,13 @@ async def rediscovery_page(request: Request):
     if not _is_authenticated(request):
         return templates.TemplateResponse("login.html", {"request": request, "version": APP_VERSION})
     return templates.TemplateResponse("rediscovery.html", {"request": request, "version": APP_VERSION})
+
+
+@app.get("/sync")
+async def sync_page(request: Request):
+    if not _is_authenticated(request):
+        return templates.TemplateResponse("login.html", {"request": request, "version": APP_VERSION})
+    return templates.TemplateResponse("loved_sync.html", {"request": request, "version": APP_VERSION})
 
 
 @app.get("/unauthorized")

--- a/cloud/app/routers/loved_sync.py
+++ b/cloud/app/routers/loved_sync.py
@@ -1,0 +1,134 @@
+"""
+Loved Sync routes — Last.fm auth flow + diff API.
+"""
+
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+
+from app.config import get_base_url, get_lastfm_api_key, get_lastfm_api_secret, get_lastfm_username
+from app.database import (
+    add_loved_sync_ignore,
+    clear_lastfm_session,
+    get_lastfm_session,
+    remove_loved_sync_ignore,
+    save_lastfm_session,
+)
+from app.lastfm_api import LastfmAuthError, get_session_from_token, track_love
+from app.loved_sync import compute_diff
+from app.routers.deps import require_auth
+from app.spotify_api import CredentialError
+from app.state import app_state
+
+router = APIRouter(tags=["loved_sync"])
+
+
+# ── Last.fm web auth flow ────────────────────────────────────────
+
+
+@router.get("/lastfm/auth/login", dependencies=[Depends(require_auth)])
+async def lastfm_login():
+    """Redirect to Last.fm's authorization page."""
+    api_key = get_lastfm_api_key()
+    if not api_key:
+        return RedirectResponse("/sync?error=no_api_key")
+    if not get_lastfm_api_secret():
+        return RedirectResponse("/sync?error=no_api_secret")
+    cb = f"{get_base_url()}/lastfm/auth/callback"
+    params = {"api_key": api_key, "cb": cb}
+    return RedirectResponse(f"https://www.last.fm/api/auth/?{urlencode(params)}")
+
+
+@router.get("/lastfm/auth/callback")
+async def lastfm_callback(request: Request, token: str = ""):
+    """Exchange the one-time token for a session key and store it."""
+    if not request.session.get("authenticated", False):
+        return RedirectResponse("/")
+    if not token:
+        return RedirectResponse("/sync?error=no_token")
+
+    try:
+        session = await get_session_from_token(token)
+    except LastfmAuthError as e:
+        return RedirectResponse(f"/sync?error=auth_failed&detail={str(e)[:200]}")
+
+    await save_lastfm_session(session["key"], session.get("name", ""))
+    return RedirectResponse("/sync?authorized=1")
+
+
+@router.post("/lastfm/auth/logout", dependencies=[Depends(require_auth)])
+async def lastfm_logout():
+    await clear_lastfm_session()
+    return {"ok": True}
+
+
+# ── Loved sync API ───────────────────────────────────────────────
+
+
+@router.get("/api/loved-sync/status", dependencies=[Depends(require_auth)])
+async def status():
+    """Check whether Last.fm is authorized and creds are available."""
+    session = await get_lastfm_session()
+    return {
+        "authorized": session is not None,
+        "lastfm_username": (session or {}).get("username", "") or get_lastfm_username(),
+        "has_api_secret": bool(get_lastfm_api_secret()),
+    }
+
+
+@router.get("/api/loved-sync/diff", dependencies=[Depends(require_auth)])
+async def diff():
+    """Compute the Liked-vs-Loved diff."""
+    client = app_state.spotify_client
+    if not client:
+        raise HTTPException(status_code=503, detail="Spotify client not ready")
+
+    username = get_lastfm_username()
+    if not username:
+        raise HTTPException(status_code=400, detail="LASTFM_USERNAME is not set.")
+
+    try:
+        result = await compute_diff(client, username)
+    except CredentialError as e:
+        raise HTTPException(status_code=401, detail=str(e))
+
+    if not result.get("ok"):
+        raise HTTPException(status_code=502, detail=result.get("error") or "Sync failed")
+    return result
+
+
+class LoveRequest(BaseModel):
+    artist: str
+    track: str
+
+
+@router.post("/api/loved-sync/love", dependencies=[Depends(require_auth)])
+async def love(body: LoveRequest):
+    session = await get_lastfm_session()
+    if not session:
+        raise HTTPException(status_code=401, detail="Not authorized with Last.fm.")
+
+    ok, err = await track_love(body.artist.strip(), body.track.strip(), session["session_key"])
+    if not ok:
+        raise HTTPException(status_code=502, detail=err or "Last.fm love failed")
+    return {"ok": True}
+
+
+class IgnoreRequest(BaseModel):
+    track_id: str
+
+
+@router.post("/api/loved-sync/ignore", dependencies=[Depends(require_auth)])
+async def ignore(body: IgnoreRequest):
+    if not body.track_id.strip():
+        raise HTTPException(status_code=400, detail="track_id is required")
+    await add_loved_sync_ignore(body.track_id.strip())
+    return {"ok": True}
+
+
+@router.post("/api/loved-sync/unignore", dependencies=[Depends(require_auth)])
+async def unignore(body: IgnoreRequest):
+    await remove_loved_sync_ignore(body.track_id.strip())
+    return {"ok": True}

--- a/cloud/app/routers/loved_sync.py
+++ b/cloud/app/routers/loved_sync.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 from app.config import get_base_url, get_lastfm_api_key, get_lastfm_api_secret, get_lastfm_username
 from app.database import (
     add_loved_sync_ignore,
+    add_track_alias,
     clear_lastfm_session,
     get_lastfm_session,
     remove_loved_sync_ignore,
@@ -113,6 +114,30 @@ async def love(body: LoveRequest):
     ok, err = await track_love(body.artist.strip(), body.track.strip(), session["session_key"])
     if not ok:
         raise HTTPException(status_code=502, detail=err or "Last.fm love failed")
+    return {"ok": True}
+
+
+class MatchRequest(BaseModel):
+    track_id: str
+    artist: str
+    spotify_name: str
+    lastfm_name: str
+
+
+@router.post("/api/loved-sync/match", dependencies=[Depends(require_auth)])
+async def match(body: MatchRequest):
+    """Create a track_alias mapping Spotify name -> Last.fm name.
+
+    Writes to the same track_aliases table the worker uses, so the alias
+    immediately applies to skip-check, mapping-fail, and Loved Sync diff.
+    """
+    track_id = body.track_id.strip()
+    artist = body.artist.strip()
+    spotify_name = body.spotify_name.strip()
+    lastfm_name = body.lastfm_name.strip()
+    if not (track_id and artist and spotify_name and lastfm_name):
+        raise HTTPException(status_code=400, detail="track_id, artist, spotify_name, and lastfm_name are required")
+    await add_track_alias(track_id, artist, spotify_name, lastfm_name)
     return {"ok": True}
 
 

--- a/cloud/app/spotify_api.py
+++ b/cloud/app/spotify_api.py
@@ -247,6 +247,39 @@ class SpotifyClient:
         await self._put("https://api.spotify.com/v1/me/player/play", json={"context_uri": context_uri})
         return True
 
+    async def get_all_saved_tracks(self) -> list[dict]:
+        """Return all of the user's Liked Songs (paginates automatically).
+
+        Each entry: {id, name, artist, added_at}.
+        """
+        results: list[dict] = []
+        offset = 0
+        while True:
+            r = await self._get(
+                "https://api.spotify.com/v1/me/tracks",
+                params={"limit": 50, "offset": offset},
+            )
+            if r is None or r.status_code != 200:
+                break
+            data = r.json() or {}
+            for entry in data.get("items") or []:
+                track = entry.get("track") or {}
+                if not track or not track.get("id"):
+                    continue
+                artists = track.get("artists") or []
+                results.append(
+                    {
+                        "id": track["id"],
+                        "name": track.get("name", ""),
+                        "artist": artists[0]["name"] if artists else "Unknown",
+                        "added_at": entry.get("added_at", ""),
+                    }
+                )
+            if not data.get("next"):
+                break
+            offset += 50
+        return results
+
     async def is_track_liked(self, track_id: str) -> bool:
         r = await self._get("https://api.spotify.com/v1/me/tracks/contains", params={"ids": track_id})
         if r is None or r.status_code != 200:

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -796,6 +796,69 @@ input:focus, select:focus {
     min-width: 0;
 }
 
+/* ── Loved Sync ──────────────────────────────────── */
+
+.sync-status-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.sync-summary {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px 16px;
+    font-size: 0.85rem;
+}
+
+.sync-list {
+    max-height: 60vh;
+    overflow-y: auto;
+}
+
+.sync-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--border-secondary);
+}
+
+.sync-row:last-child { border-bottom: none; }
+
+.sync-row-info {
+    min-width: 0;
+    flex: 1;
+}
+
+.sync-row-artist {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sync-row-track {
+    font-size: 0.95rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sync-row-alias {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+}
+
+.sync-row-actions {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
 /* ── Settings Grid ──────────────────────────────── */
 
 .settings-grid {

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -798,6 +798,14 @@ input:focus, select:focus {
 
 /* ── Loved Sync ──────────────────────────────────── */
 
+.sync-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 16px;
+}
+
+.sync-col > .card:last-child { margin-bottom: 0; }
+
 .sync-status-row {
     display: flex;
     justify-content: space-between;
@@ -941,5 +949,14 @@ input:focus, select:focus {
 
     .container:has(.insights-columns) {
         max-width: 1200px;
+    }
+
+    .sync-grid {
+        grid-template-columns: minmax(280px, 1fr) 1fr 1fr;
+        align-items: start;
+    }
+
+    .container:has(.sync-grid) {
+        max-width: 1400px;
     }
 }

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -867,6 +867,70 @@ input:focus, select:focus {
     flex-shrink: 0;
 }
 
+/* Inline candidates panel under a needs-love row */
+.sync-candidates {
+    background: var(--bg-input);
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    padding: 6px;
+    margin: 4px 0 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.sync-candidate {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    border: 1px solid var(--border-secondary);
+    background: var(--bg-card);
+    color: var(--text-primary);
+    border-radius: 4px;
+    cursor: pointer;
+    text-align: left;
+    font-size: 0.85rem;
+    transition: border-color 0.15s, background 0.15s;
+}
+
+.sync-candidate:hover {
+    border-color: var(--accent);
+    background: var(--bg-hover);
+}
+
+.sync-candidate-info {
+    min-width: 0;
+    flex: 1;
+}
+
+.sync-candidate-artist {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sync-candidate-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sync-candidate-score {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    flex-shrink: 0;
+}
+
+.sync-candidate-manual {
+    color: var(--text-secondary);
+    font-style: italic;
+    justify-content: center;
+}
+
 /* ── Settings Grid ──────────────────────────────── */
 
 .settings-grid {

--- a/cloud/app/static/js/loved_sync.js
+++ b/cloud/app/static/js/loved_sync.js
@@ -81,10 +81,42 @@
     refreshBtn.addEventListener('click', loadDiff);
 
     // ── Render ──────────────────────────────────────────
+    function normKey(s) {
+        return (s || '').trim().toLowerCase();
+    }
+
+    function decStat(el) {
+        const n = parseInt(el.textContent, 10);
+        if (!isNaN(n)) el.textContent = Math.max(0, n - 1);
+    }
+
+    function incStat(el) {
+        const n = parseInt(el.textContent, 10);
+        el.textContent = (isNaN(n) ? 0 : n) + 1;
+    }
+
+    function refreshEmptyState() {
+        if (!needsLoveList.children.length) needsLoveCard.classList.add('hidden');
+        if (!lovedOnlyList.children.length) lovedOnlyCard.classList.add('hidden');
+        if (!needsLoveList.children.length && !lovedOnlyList.children.length) {
+            allClean.classList.remove('hidden');
+        }
+    }
+
+    function findLovedRow(artist, name) {
+        const aKey = normKey(artist);
+        const nKey = normKey(name);
+        return Array.from(lovedOnlyList.querySelectorAll('.sync-row')).find(
+            r => r.dataset.artistKey === aKey && r.dataset.nameKey === nKey
+        );
+    }
+
     function renderRow(track, withButtons) {
         const row = document.createElement('div');
         row.className = 'sync-row';
         row.dataset.id = track.id || '';
+        row.dataset.artistKey = normKey(track.artist);
+        row.dataset.nameKey = normKey(track.name);
 
         const info = document.createElement('div');
         info.className = 'sync-row-info';
@@ -190,10 +222,16 @@
                 showError('Match failed: ' + (err.detail || r.status));
                 return;
             }
-            // Alias created. Re-fetch the diff so both sides update consistently.
+            // Optimistic update: drop both rows, fix counts, no full refresh.
             panel.remove();
             row.remove();
-            await loadDiff();
+            decStat(statNeedsLove);
+            const lovedRow = findLovedRow(candidate.artist, candidate.name);
+            if (lovedRow) {
+                lovedRow.remove();
+                decStat(statLovedOnly);
+            }
+            refreshEmptyState();
         } catch (e) {
             showError('Network error.');
         }
@@ -222,6 +260,8 @@
                 return false;
             }
             row.remove();
+            decStat(statNeedsLove);
+            refreshEmptyState();
             return true;
         } catch (e) {
             btn.textContent = 'Love';
@@ -245,6 +285,9 @@
                 return;
             }
             row.remove();
+            decStat(statNeedsLove);
+            incStat(statIgnored);
+            refreshEmptyState();
         } catch (e) {
             btn.disabled = false;
             showError('Network error.');

--- a/cloud/app/static/js/loved_sync.js
+++ b/cloud/app/static/js/loved_sync.js
@@ -1,0 +1,247 @@
+// Loved Sync — frontend logic
+
+(async function () {
+    const errorBanner = document.getElementById('error-banner');
+    const errorText = document.getElementById('error-text');
+    const authCard = document.getElementById('auth-card');
+    const content = document.getElementById('content');
+    const lastfmUsername = document.getElementById('lastfm-username');
+    const disconnectBtn = document.getElementById('disconnect-btn');
+    const refreshBtn = document.getElementById('refresh-btn');
+    const loading = document.getElementById('loading');
+
+    const statSpotify = document.getElementById('stat-spotify');
+    const statLastfm = document.getElementById('stat-lastfm');
+    const statNeedsLove = document.getElementById('stat-needs-love');
+    const statLovedOnly = document.getElementById('stat-loved-only');
+    const statIgnored = document.getElementById('stat-ignored');
+
+    const needsLoveCard = document.getElementById('needs-love-card');
+    const needsLoveList = document.getElementById('needs-love-list');
+    const loveAllBtn = document.getElementById('love-all-btn');
+    const lovedOnlyCard = document.getElementById('loved-only-card');
+    const lovedOnlyList = document.getElementById('loved-only-list');
+    const allClean = document.getElementById('all-clean');
+
+    function showError(msg) {
+        errorText.textContent = msg;
+        errorBanner.classList.remove('hidden');
+    }
+
+    function hideError() {
+        errorBanner.classList.add('hidden');
+    }
+
+    function parseQueryError() {
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('error')) {
+            const detail = params.get('detail') || '';
+            showError('Last.fm authorization failed: ' + params.get('error') + (detail ? ' - ' + detail : ''));
+        }
+        if (params.get('authorized') === '1') {
+            history.replaceState({}, '', '/sync');
+        }
+    }
+    parseQueryError();
+
+    // ── Status check ────────────────────────────────────
+    async function checkStatus() {
+        const r = await fetch('/api/loved-sync/status');
+        if (!r.ok) {
+            showError('Could not load status.');
+            return null;
+        }
+        return await r.json();
+    }
+
+    const status = await checkStatus();
+    if (!status) return;
+
+    if (!status.has_api_secret) {
+        showError('LASTFM_API_SECRET env var is not set on the server. Required for write operations.');
+        return;
+    }
+
+    if (!status.authorized) {
+        authCard.classList.remove('hidden');
+        return;
+    }
+
+    lastfmUsername.textContent = status.lastfm_username || '(unknown)';
+    content.classList.remove('hidden');
+
+    // ── Disconnect ──────────────────────────────────────
+    disconnectBtn.addEventListener('click', async function () {
+        if (!confirm('Disconnect Last.fm? You will need to reauthorize to use Loved Sync.')) return;
+        await fetch('/lastfm/auth/logout', {method: 'POST'});
+        location.reload();
+    });
+
+    // ── Refresh ─────────────────────────────────────────
+    refreshBtn.addEventListener('click', loadDiff);
+
+    // ── Render ──────────────────────────────────────────
+    function renderRow(track, withButtons) {
+        const row = document.createElement('div');
+        row.className = 'sync-row';
+        row.dataset.id = track.id || '';
+
+        const info = document.createElement('div');
+        info.className = 'sync-row-info';
+        const artist = document.createElement('div');
+        artist.className = 'sync-row-artist';
+        artist.textContent = track.artist;
+        const name = document.createElement('div');
+        name.className = 'sync-row-track';
+        name.textContent = track.name;
+        if (track.lastfm_name && track.lastfm_name !== track.name) {
+            const alias = document.createElement('span');
+            alias.className = 'sync-row-alias';
+            alias.textContent = ' → ' + track.lastfm_name;
+            name.appendChild(alias);
+        }
+        info.appendChild(artist);
+        info.appendChild(name);
+        row.appendChild(info);
+
+        if (withButtons) {
+            const actions = document.createElement('div');
+            actions.className = 'sync-row-actions';
+
+            const loveBtn = document.createElement('button');
+            loveBtn.className = 'btn btn-sm btn-accent';
+            loveBtn.textContent = 'Love';
+            loveBtn.addEventListener('click', () => loveTrack(track, row, loveBtn));
+
+            const ignoreBtn = document.createElement('button');
+            ignoreBtn.className = 'btn btn-sm';
+            ignoreBtn.textContent = 'Ignore';
+            ignoreBtn.addEventListener('click', () => ignoreTrack(track, row, ignoreBtn));
+
+            actions.appendChild(loveBtn);
+            actions.appendChild(ignoreBtn);
+            row.appendChild(actions);
+        }
+
+        return row;
+    }
+
+    async function loveTrack(track, row, btn) {
+        btn.disabled = true;
+        btn.textContent = '...';
+        try {
+            const r = await fetch('/api/loved-sync/love', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({artist: track.artist, track: track.lastfm_name || track.name}),
+            });
+            if (!r.ok) {
+                const err = await r.json().catch(() => ({}));
+                btn.textContent = 'Love';
+                btn.disabled = false;
+                showError('Love failed: ' + (err.detail || r.status));
+                return false;
+            }
+            row.remove();
+            return true;
+        } catch (e) {
+            btn.textContent = 'Love';
+            btn.disabled = false;
+            showError('Network error.');
+            return false;
+        }
+    }
+
+    async function ignoreTrack(track, row, btn) {
+        btn.disabled = true;
+        try {
+            const r = await fetch('/api/loved-sync/ignore', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({track_id: track.id}),
+            });
+            if (!r.ok) {
+                btn.disabled = false;
+                showError('Ignore failed.');
+                return;
+            }
+            row.remove();
+        } catch (e) {
+            btn.disabled = false;
+            showError('Network error.');
+        }
+    }
+
+    loveAllBtn.addEventListener('click', async function () {
+        const rows = Array.from(needsLoveList.querySelectorAll('.sync-row'));
+        if (!rows.length) return;
+        if (!confirm('Love ' + rows.length + ' tracks on Last.fm?')) return;
+        loveAllBtn.disabled = true;
+        loveAllBtn.textContent = 'Loving... 0/' + rows.length;
+        let done = 0, failed = 0;
+        for (const row of rows) {
+            const loveBtn = row.querySelector('.btn-accent');
+            if (!loveBtn) continue;
+            const artist = row.querySelector('.sync-row-artist').textContent;
+            const trackEl = row.querySelector('.sync-row-track');
+            const aliasEl = trackEl.querySelector('.sync-row-alias');
+            const trackName = aliasEl ? aliasEl.textContent.replace(/^ → /, '') : trackEl.textContent;
+            const ok = await loveTrack({artist: artist, name: trackName, lastfm_name: trackName}, row, loveBtn);
+            if (ok) done++; else failed++;
+            loveAllBtn.textContent = 'Loving... ' + (done + failed) + '/' + rows.length;
+            // Small delay to be nice to Last.fm
+            await new Promise(r => setTimeout(r, 200));
+        }
+        loveAllBtn.disabled = false;
+        loveAllBtn.textContent = 'Love all';
+        await loadDiff();
+        if (failed) showError(failed + ' track(s) failed to love.');
+    });
+
+    // ── Load diff ───────────────────────────────────────
+    async function loadDiff() {
+        hideError();
+        loading.classList.remove('hidden');
+        needsLoveCard.classList.add('hidden');
+        lovedOnlyCard.classList.add('hidden');
+        allClean.classList.add('hidden');
+
+        try {
+            const r = await fetch('/api/loved-sync/diff');
+            if (!r.ok) {
+                const err = await r.json().catch(() => ({}));
+                showError('Diff failed: ' + (err.detail || r.status));
+                loading.classList.add('hidden');
+                return;
+            }
+            const data = await r.json();
+
+            statSpotify.textContent = data.spotify_total;
+            statLastfm.textContent = data.lastfm_total;
+            statNeedsLove.textContent = data.needs_love.length;
+            statLovedOnly.textContent = data.loved_not_liked.length;
+            statIgnored.textContent = data.ignored_count;
+
+            needsLoveList.innerHTML = '';
+            for (const t of data.needs_love) {
+                needsLoveList.appendChild(renderRow(t, true));
+            }
+            lovedOnlyList.innerHTML = '';
+            for (const t of data.loved_not_liked) {
+                lovedOnlyList.appendChild(renderRow(t, false));
+            }
+
+            if (data.needs_love.length) needsLoveCard.classList.remove('hidden');
+            if (data.loved_not_liked.length) lovedOnlyCard.classList.remove('hidden');
+            if (!data.needs_love.length && !data.loved_not_liked.length) {
+                allClean.classList.remove('hidden');
+            }
+        } catch (e) {
+            showError('Network error loading diff.');
+        } finally {
+            loading.classList.add('hidden');
+        }
+    }
+
+    await loadDiff();
+})();

--- a/cloud/app/static/js/loved_sync.js
+++ b/cloud/app/static/js/loved_sync.js
@@ -108,6 +108,15 @@
             const actions = document.createElement('div');
             actions.className = 'sync-row-actions';
 
+            const hasCandidates = (track.candidates || []).length > 0;
+            if (hasCandidates) {
+                const matchBtn = document.createElement('button');
+                matchBtn.className = 'btn btn-sm';
+                matchBtn.textContent = 'Match';
+                matchBtn.addEventListener('click', () => toggleCandidates(row, track, matchBtn));
+                actions.appendChild(matchBtn);
+            }
+
             const loveBtn = document.createElement('button');
             loveBtn.className = 'btn btn-sm btn-accent';
             loveBtn.textContent = 'Love';
@@ -124,6 +133,76 @@
         }
 
         return row;
+    }
+
+    function toggleCandidates(row, track, btn) {
+        const existing = row.nextElementSibling;
+        if (existing && existing.classList.contains('sync-candidates')) {
+            existing.remove();
+            btn.classList.remove('btn-accent');
+            return;
+        }
+        btn.classList.add('btn-accent');
+
+        const panel = document.createElement('div');
+        panel.className = 'sync-candidates';
+
+        for (const cand of track.candidates) {
+            const item = document.createElement('button');
+            item.className = 'sync-candidate';
+            item.innerHTML =
+                '<div class="sync-candidate-info">' +
+                '<div class="sync-candidate-artist">' + escapeHtml(cand.artist) + '</div>' +
+                '<div class="sync-candidate-name">' + escapeHtml(cand.name) + '</div>' +
+                '</div>' +
+                '<span class="sync-candidate-score">' + Math.round(cand.score * 100) + '%</span>';
+            item.addEventListener('click', () => createMatch(track, cand, row, panel));
+            panel.appendChild(item);
+        }
+
+        const manual = document.createElement('button');
+        manual.className = 'sync-candidate sync-candidate-manual';
+        manual.textContent = 'None of these — enter Last.fm name manually';
+        manual.addEventListener('click', () => {
+            const lfName = prompt('Last.fm track name (artist will stay "' + track.artist + '"):', track.name);
+            if (!lfName || !lfName.trim()) return;
+            createMatch(track, {artist: track.artist, name: lfName.trim()}, row, panel);
+        });
+        panel.appendChild(manual);
+
+        row.insertAdjacentElement('afterend', panel);
+    }
+
+    async function createMatch(track, candidate, row, panel) {
+        try {
+            const r = await fetch('/api/loved-sync/match', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    track_id: track.id,
+                    artist: track.artist,
+                    spotify_name: track.name,
+                    lastfm_name: candidate.name,
+                }),
+            });
+            if (!r.ok) {
+                const err = await r.json().catch(() => ({}));
+                showError('Match failed: ' + (err.detail || r.status));
+                return;
+            }
+            // Alias created. Re-fetch the diff so both sides update consistently.
+            panel.remove();
+            row.remove();
+            await loadDiff();
+        } catch (e) {
+            showError('Network error.');
+        }
+    }
+
+    function escapeHtml(s) {
+        return String(s).replace(/[&<>"']/g, c => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+        }[c]));
     }
 
     async function loveTrack(track, row, btn) {

--- a/cloud/app/templates/loved_sync.html
+++ b/cloud/app/templates/loved_sync.html
@@ -16,44 +16,52 @@
     </div>
 
     <div id="content" class="hidden">
-        <div class="card">
-            <div class="card-title">Status</div>
-            <div class="sync-status-row">
-                <span>Authorized as <strong id="lastfm-username">-</strong></span>
-                <button id="disconnect-btn" class="btn btn-sm btn-danger">Disconnect</button>
+        <div class="sync-grid">
+            <div class="sync-col">
+                <div class="card">
+                    <div class="card-title">Status</div>
+                    <div class="sync-status-row">
+                        <span>Authorized as <strong id="lastfm-username">-</strong></span>
+                        <button id="disconnect-btn" class="btn btn-sm btn-danger">Disconnect</button>
+                    </div>
+                </div>
+
+                <div class="card">
+                    <div class="card-title">Summary</div>
+                    <div class="sync-summary">
+                        <div><span class="text-secondary">Spotify Liked:</span> <strong id="stat-spotify">-</strong></div>
+                        <div><span class="text-secondary">Last.fm Loved:</span> <strong id="stat-lastfm">-</strong></div>
+                        <div><span class="text-secondary">Needs love:</span> <strong id="stat-needs-love">-</strong></div>
+                        <div><span class="text-secondary">Loved, not Liked:</span> <strong id="stat-loved-only">-</strong></div>
+                        <div><span class="text-secondary">Ignored:</span> <strong id="stat-ignored">-</strong></div>
+                    </div>
+                    <button id="refresh-btn" class="btn btn-full mt-8">Refresh</button>
+                </div>
+
+                <div id="loading" class="card hidden">
+                    <div class="text-secondary text-center">Comparing libraries...</div>
+                </div>
+
+                <div id="all-clean" class="card hidden">
+                    <div class="text-center text-secondary">Everything in sync.</div>
+                </div>
             </div>
-        </div>
 
-        <div class="card">
-            <div class="card-title">Summary</div>
-            <div class="sync-summary">
-                <div><span class="text-secondary">Spotify Liked:</span> <strong id="stat-spotify">-</strong></div>
-                <div><span class="text-secondary">Last.fm Loved:</span> <strong id="stat-lastfm">-</strong></div>
-                <div><span class="text-secondary">Needs love:</span> <strong id="stat-needs-love">-</strong></div>
-                <div><span class="text-secondary">Loved, not Liked:</span> <strong id="stat-loved-only">-</strong></div>
-                <div><span class="text-secondary">Ignored:</span> <strong id="stat-ignored">-</strong></div>
+            <div class="sync-col">
+                <div id="needs-love-card" class="card hidden">
+                    <div class="card-title">Liked on Spotify, not Loved on Last.fm</div>
+                    <button id="love-all-btn" class="btn btn-accent btn-sm mb-16">Love all</button>
+                    <div id="needs-love-list" class="sync-list"></div>
+                </div>
             </div>
-            <button id="refresh-btn" class="btn btn-full mt-8">Refresh</button>
-        </div>
 
-        <div id="loading" class="card hidden">
-            <div class="text-secondary text-center">Comparing libraries...</div>
-        </div>
-
-        <div id="needs-love-card" class="card hidden">
-            <div class="card-title">Liked on Spotify, not Loved on Last.fm</div>
-            <button id="love-all-btn" class="btn btn-accent btn-sm mb-16">Love all</button>
-            <div id="needs-love-list" class="sync-list"></div>
-        </div>
-
-        <div id="loved-only-card" class="card hidden">
-            <div class="card-title">Loved on Last.fm, not Liked on Spotify</div>
-            <p class="help-text mb-16">Read-only. Like these on Spotify yourself if you want.</p>
-            <div id="loved-only-list" class="sync-list"></div>
-        </div>
-
-        <div id="all-clean" class="card hidden">
-            <div class="text-center text-secondary">Everything in sync.</div>
+            <div class="sync-col">
+                <div id="loved-only-card" class="card hidden">
+                    <div class="card-title">Loved on Last.fm, not Liked on Spotify</div>
+                    <p class="help-text mb-16">Read-only. Like these on Spotify yourself if you want.</p>
+                    <div id="loved-only-list" class="sync-list"></div>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/cloud/app/templates/loved_sync.html
+++ b/cloud/app/templates/loved_sync.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+{% block title %}Loved Sync - Spotify Auto-Skipper{% endblock %}
+{% block content %}
+<div class="container">
+    <h1 class="page-title">Loved Sync</h1>
+    <p class="text-secondary mb-16">Compare your Spotify Liked Songs to your Last.fm Loved Tracks. Love missing tracks on Last.fm with one click.</p>
+
+    <div id="error-banner" class="card hidden" style="border-color: var(--color-error);">
+        <div id="error-text"></div>
+    </div>
+
+    <div id="auth-card" class="card hidden">
+        <div class="card-title">Connect Last.fm</div>
+        <p class="text-secondary mb-16">Authorize this app to mark tracks as Loved on your Last.fm account. Session never expires.</p>
+        <a id="auth-btn" href="/lastfm/auth/login" class="btn btn-accent btn-full">Authorize Last.fm</a>
+    </div>
+
+    <div id="content" class="hidden">
+        <div class="card">
+            <div class="card-title">Status</div>
+            <div class="sync-status-row">
+                <span>Authorized as <strong id="lastfm-username">-</strong></span>
+                <button id="disconnect-btn" class="btn btn-sm btn-danger">Disconnect</button>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-title">Summary</div>
+            <div class="sync-summary">
+                <div><span class="text-secondary">Spotify Liked:</span> <strong id="stat-spotify">-</strong></div>
+                <div><span class="text-secondary">Last.fm Loved:</span> <strong id="stat-lastfm">-</strong></div>
+                <div><span class="text-secondary">Needs love:</span> <strong id="stat-needs-love">-</strong></div>
+                <div><span class="text-secondary">Loved, not Liked:</span> <strong id="stat-loved-only">-</strong></div>
+                <div><span class="text-secondary">Ignored:</span> <strong id="stat-ignored">-</strong></div>
+            </div>
+            <button id="refresh-btn" class="btn btn-full mt-8">Refresh</button>
+        </div>
+
+        <div id="loading" class="card hidden">
+            <div class="text-secondary text-center">Comparing libraries...</div>
+        </div>
+
+        <div id="needs-love-card" class="card hidden">
+            <div class="card-title">Liked on Spotify, not Loved on Last.fm</div>
+            <button id="love-all-btn" class="btn btn-accent btn-sm mb-16">Love all</button>
+            <div id="needs-love-list" class="sync-list"></div>
+        </div>
+
+        <div id="loved-only-card" class="card hidden">
+            <div class="card-title">Loved on Last.fm, not Liked on Spotify</div>
+            <p class="help-text mb-16">Read-only. Like these on Spotify yourself if you want.</p>
+            <div id="loved-only-list" class="sync-list"></div>
+        </div>
+
+        <div id="all-clean" class="card hidden">
+            <div class="text-center text-secondary">Everything in sync.</div>
+        </div>
+    </div>
+</div>
+
+<script src="/static/js/loved_sync.js?v={{ version }}"></script>
+{% endblock %}

--- a/cloud/app/templates/settings.html
+++ b/cloud/app/templates/settings.html
@@ -103,6 +103,8 @@
             <div class="card-title">Tools</div>
             <a href="/rediscovery" class="btn btn-full">Rediscovery</a>
             <div class="help-text mt-8">Find songs in a playlist you haven't listened to in a while.</div>
+            <a href="/sync" class="btn btn-full mt-16">Loved Sync</a>
+            <div class="help-text mt-8">Compare Spotify Liked Songs to Last.fm Loved Tracks.</div>
         </div>
 
         <div class="card">


### PR DESCRIPTION
## Summary
- New **/sync** page (linked from Settings → Tools) compares Spotify Liked Songs against Last.fm Loved Tracks
- One-way write: per-row + bulk **Love** action sends `track.love` to Last.fm. Reverse list (Loved, not Liked) is read-only.
- Matching reuses the worker's alias-aware key — same logic that decides whether to skip a playing track. Per-track **Ignore** persists in DB.
- Last.fm web auth flow (`auth.getSession`); encrypted session key in new `lastfm_auth` table; session never expires.

## New env var
`LASTFM_API_SECRET` (required for signed write methods). Add to VPS `.env` before deploy.

## New tables
- `lastfm_auth` — encrypted session key + username
- `loved_sync_ignored` — Spotify track_ids hidden from "needs love" list

## New endpoints
- `GET /sync` — page
- `GET /lastfm/auth/login` + `GET /lastfm/auth/callback` — OAuth flow
- `POST /lastfm/auth/logout`
- `GET /api/loved-sync/status`
- `GET /api/loved-sync/diff`
- `POST /api/loved-sync/love`
- `POST /api/loved-sync/ignore` + `unignore`

## Test plan
- [ ] Add `LASTFM_API_SECRET` to VPS `.env`
- [ ] Deploy via `/deploy`
- [ ] Open `/sync` → click **Authorize Last.fm** → approve on last.fm → returns to `/sync`
- [ ] Diff loads, summary counts populate
- [ ] Love a single track → verify on last.fm/user/<you>/loved
- [ ] Ignore a track → re-Refresh → confirms it's gone from "needs love"
- [ ] Bulk **Love all** on a small set
- [ ] Disconnect button clears session, re-shows auth card