### PR TITLE
Adaptive skip window (v3.10.0-1)

### DIFF
--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.10.0-3"
+APP_VERSION = "v3.10.0-4"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.10.0-1"
+APP_VERSION = "v3.10.0-2"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.9.1"
+APP_VERSION = "v3.10.0-1"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.10.0-2"
+APP_VERSION = "v3.10.0-3"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.10.0-4"
+APP_VERSION = "v3.10.0"

--- a/cloud/app/config.py
+++ b/cloud/app/config.py
@@ -15,6 +15,7 @@ CONFIG_DEFAULTS = {
     "enable_restart_pattern": True,
     "restart_pattern_song_count": 5,
     "restart_pattern_day_diff": 2,
+    "enable_adaptive_skip_window": True,
     "dummy_playlist_id": "37i9dQZF1DX0XUsuxWHRQd",
     "trash_playlist_id": "",
     "always_play_liked_songs": True,
@@ -36,6 +37,7 @@ _BOOL_KEYS = {
     "enable_restart_pattern",
     "always_play_liked_songs",
     "enable_never_skip_artists",
+    "enable_adaptive_skip_window",
 }
 
 

--- a/cloud/app/routers/settings.py
+++ b/cloud/app/routers/settings.py
@@ -24,6 +24,7 @@ class SettingsUpdate(BaseModel):
     enable_restart_pattern: Optional[bool] = None
     restart_pattern_song_count: Optional[int] = None
     restart_pattern_day_diff: Optional[int] = None
+    enable_adaptive_skip_window: Optional[bool] = None
     dummy_playlist_id: Optional[str] = None
     trash_playlist_id: Optional[str] = None
     always_play_liked_songs: Optional[bool] = None

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -210,7 +210,7 @@ input:focus, select:focus {
 }
 
 .form-group .help-text,
-.toggle + .help-text {
+.toggle-text .help-text {
     font-size: 0.8rem;
     color: var(--text-muted);
     margin-top: 4px;
@@ -240,6 +240,13 @@ input:focus, select:focus {
 
 .toggle-label {
     font-size: 0.9rem;
+}
+
+.toggle-text {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    margin-right: 16px;
 }
 
 .toggle-switch {

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -209,7 +209,8 @@ input:focus, select:focus {
     margin-bottom: 6px;
 }
 
-.form-group .help-text {
+.form-group .help-text,
+.toggle + .help-text {
     font-size: 0.8rem;
     color: var(--text-muted);
     margin-top: 4px;

--- a/cloud/app/static/js/app.js
+++ b/cloud/app/static/js/app.js
@@ -119,19 +119,19 @@ function initDashboard() {
                 if (!data.track) {
                     likeBtn.disabled = true;
                     likeBtn.textContent = "Add to Liked Songs";
-                    likeBtn.classList.remove("btn-accent");
+                    likeBtn.classList.remove("btn-danger");
                 } else if (data.is_liked === true) {
                     likeBtn.disabled = false;
                     likeBtn.textContent = "♥ Remove from Liked Songs";
-                    likeBtn.classList.add("btn-accent");
+                    likeBtn.classList.add("btn-danger");
                 } else if (data.is_liked === false) {
                     likeBtn.disabled = false;
                     likeBtn.textContent = "♡ Add to Liked Songs";
-                    likeBtn.classList.remove("btn-accent");
+                    likeBtn.classList.remove("btn-danger");
                 } else {
                     likeBtn.disabled = true;
                     likeBtn.textContent = "Add to Liked Songs";
-                    likeBtn.classList.remove("btn-accent");
+                    likeBtn.classList.remove("btn-danger");
                 }
             }
         } catch (e) {

--- a/cloud/app/templates/settings.html
+++ b/cloud/app/templates/settings.html
@@ -50,13 +50,15 @@
                 </div>
 
                 <div class="toggle">
-                    <span class="toggle-label">Adaptive skip window</span>
+                    <div class="toggle-text">
+                        <span class="toggle-label">Adaptive skip window</span>
+                        <div class="help-text">After 5 consecutive skips the window shrinks by 33%; after 10, by 66%. Resets on the first non-skip.</div>
+                    </div>
                     <label class="toggle-switch">
                         <input type="checkbox" data-setting="enable_adaptive_skip_window">
                         <span class="toggle-slider"></span>
                     </label>
                 </div>
-                <div class="help-text">After 5 consecutive skips the window shrinks by 33%; after 10, by 66%. Resets on the first non-skip.</div>
             </div>
 
             <div class="card">

--- a/cloud/app/templates/settings.html
+++ b/cloud/app/templates/settings.html
@@ -48,6 +48,15 @@
                         <span class="toggle-slider"></span>
                     </label>
                 </div>
+
+                <div class="toggle">
+                    <span class="toggle-label">Adaptive skip window</span>
+                    <label class="toggle-switch">
+                        <input type="checkbox" data-setting="enable_adaptive_skip_window">
+                        <span class="toggle-slider"></span>
+                    </label>
+                </div>
+                <div class="help-text">After 5 consecutive skips the window shrinks by 33%; after 10, by 66%. Resets on the first non-skip.</div>
             </div>
 
             <div class="card">

--- a/cloud/app/worker.py
+++ b/cloud/app/worker.py
@@ -27,6 +27,21 @@ async def _log(message: str, level: str = "info"):
     await add_log(message, level)
 
 
+# Adaptive skip window: after N consecutive skips, temporarily narrow the window
+# so more songs pass through. Each level cuts the window by 33% of the base.
+ADAPTIVE_STEP_SIZE = 5
+ADAPTIVE_MAX_LEVEL = 2
+ADAPTIVE_REDUCTION_PER_LEVEL = 0.33
+
+
+def _adaptive_level(consecutive_skips: int) -> int:
+    return min(consecutive_skips // ADAPTIVE_STEP_SIZE, ADAPTIVE_MAX_LEVEL)
+
+
+def _effective_window(base_days: int, level: int) -> int:
+    return max(1, int(round(base_days * (1 - ADAPTIVE_REDUCTION_PER_LEVEL * level))))
+
+
 async def polling_loop():
     """
     Continuously check what's playing, ask Last.fm if it was scrobbled recently,
@@ -34,6 +49,31 @@ async def polling_loop():
     """
     recent_skip_days: list[int] = []
     consecutive_idle: int = 0
+    consecutive_skips: int = 0
+    adaptive_level: int = 0
+
+    async def _update_skip_streak(was_skip: bool):
+        nonlocal consecutive_skips, adaptive_level
+        new_count = consecutive_skips + 1 if was_skip else 0
+        if not settings.get("enable_adaptive_skip_window"):
+            consecutive_skips = new_count
+            adaptive_level = 0
+            return
+        new_level = _adaptive_level(new_count)
+        if new_level != adaptive_level:
+            base = settings["skip_window_days"]
+            if new_level > 0:
+                await _log(
+                    f"Adaptive skip window: {new_count} consecutive skips — "
+                    f"narrowing window to {_effective_window(base, new_level)}d (base {base}d)",
+                    "warning",
+                )
+            else:
+                await _log(
+                    f"Adaptive skip window: streak broken — restoring window to {base}d"
+                )
+        consecutive_skips = new_count
+        adaptive_level = new_level
 
     # Wait for OAuth tokens to be available
     while True:
@@ -60,7 +100,8 @@ async def polling_loop():
         f"idle_threshold={settings['idle_threshold']}, "
         f"idle_poll_interval={settings['idle_poll_interval_seconds']}s, "
         f"liked_songs={'on' if settings['always_play_liked_songs'] else 'off'}, "
-        f"restart_pattern={'on' if settings['enable_restart_pattern'] else 'off'}"
+        f"restart_pattern={'on' if settings['enable_restart_pattern'] else 'off'}, "
+        f"adaptive_window={'on' if settings['enable_adaptive_skip_window'] else 'off'}"
     )
 
     # Purge old data on startup, then every 24 hours
@@ -154,7 +195,12 @@ async def polling_loop():
                 await _log(f"Last scrobble: {last_played.strftime('%Y-%m-%d')} - {days_since} days ago")
                 app_state.last_check_message = f"Last heard {days_since} day{'s' if days_since != 1 else ''} ago"
 
-                cutoff = datetime.now(timezone.utc) - timedelta(days=settings["skip_window_days"])
+                effective_window_days = (
+                    _effective_window(settings["skip_window_days"], adaptive_level)
+                    if settings.get("enable_adaptive_skip_window")
+                    else settings["skip_window_days"]
+                )
+                cutoff = datetime.now(timezone.utc) - timedelta(days=effective_window_days)
 
                 if last_played > cutoff:
                     # Check one-time skip pause
@@ -169,6 +215,7 @@ async def polling_loop():
                             days_since,
                             track.get("context_uri"), album_name=track.get("album"),
                         )
+                        await _update_skip_streak(False)
                     # Check never-skip list
                     elif settings["enable_never_skip_artists"] and await is_artist_never_skipped(
                         track.get("artist_ids", [])
@@ -182,6 +229,7 @@ async def polling_loop():
                             days_since,
                             track.get("context_uri"), album_name=track.get("album"),
                         )
+                        await _update_skip_streak(False)
                     # Check liked songs
                     elif settings["always_play_liked_songs"] and await client.is_track_liked(track["id"]):
                         await _log("Track is in Liked Songs \u2014 not skipping")
@@ -193,6 +241,7 @@ async def polling_loop():
                             days_since,
                             track.get("context_uri"), album_name=track.get("album"),
                         )
+                        await _update_skip_streak(False)
                     else:
                         # Re-check pause flag right before skipping (user may have
                         # pressed Pause while we were querying Last.fm)
@@ -206,6 +255,7 @@ async def polling_loop():
                                 days_since,
                                 track.get("context_uri"), album_name=track.get("album"),
                             )
+                            await _update_skip_streak(False)
                             await app_state.interruptible_sleep(poll_interval)
                             continue
 
@@ -224,6 +274,7 @@ async def polling_loop():
                             days_since,
                             track.get("context_uri"), album_name=track.get("album"),
                         )
+                        await _update_skip_streak(True)
 
                         # Track skip patterns for restart detection
                         if settings["enable_restart_pattern"]:
@@ -257,6 +308,7 @@ async def polling_loop():
                         days_since,
                         track.get("context_uri"), album_name=track.get("album"),
                     )
+                    await _update_skip_streak(False)
             else:
                 await _log("No scrobble for this song \u2014 not skipping.")
                 app_state.last_check_message = "Never heard before"
@@ -268,6 +320,7 @@ async def polling_loop():
                     None,
                     track.get("context_uri"), album_name=track.get("album"),
                 )
+                await _update_skip_streak(False)
 
         except CredentialError as e:
             await _log(f"Credential error: {e}", "error")


### PR DESCRIPTION
## Summary
- New worker behavior: after 5 consecutive skips, the effective skip window shrinks to 67% of the configured base. After 10 skips, 33%. Max two reductions.
- Streak resets to level 0 on the first non-skip outcome (played, no_scrobble, liked, never_skip, skip_paused).
- New setting `enable_adaptive_skip_window` (default on) with toggle in **Settings → Skip Behavior**.
- Level changes are logged so the dashboard shows when the window narrows or restores.
- Test version: `v3.10.0-1`.

## Why
Spotify shuffle sometimes loops through recently-played tracks; the skipper then chain-skips through the whole queue. Shrinking the window temporarily lets borderline-recent songs through until Spotify recovers.

## Test plan
- [ ] Deploy `v3.10.0-1` to VPS, watch `/logs` for "Adaptive skip window" lines
- [ ] Force a 5-skip streak (e.g. on a recently played playlist) and confirm window drops to 67%
- [ ] Continue to 10 skips and confirm window drops to 33%
- [ ] Let one song play through (any non-skip outcome) and confirm window restores
- [ ] Toggle the setting off in Settings and confirm window stays at base value

Written by Claude.