### PR TITLE
Mapping issues: link last-seen timestamp to Last.fm scrobbles for that day (v3.11.0)

### DIFF
--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.10.4"
+APP_VERSION = "v3.11.0-1"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.11.0-1"
+APP_VERSION = "v3.11.0"

--- a/cloud/app/routers/insights.py
+++ b/cloud/app/routers/insights.py
@@ -5,7 +5,7 @@ Insights API routes.
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from app.config import load_settings
+from app.config import get_lastfm_username, load_settings
 from app.database import (
     add_track_alias,
     confirm_track_alias,
@@ -60,6 +60,7 @@ async def get_mapping_fails(request: Request):
     candidates = await get_mapping_fail_candidates(settings["skip_window_days"])
     return {
         "skip_window_days": settings["skip_window_days"],
+        "lastfm_username": get_lastfm_username(),
         "candidates": candidates,
     }
 

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -473,6 +473,16 @@ input:focus, select:focus {
     font-size: 0.75rem;
 }
 
+.mapping-fail-lastseen {
+    color: var(--text-secondary);
+    text-decoration: none;
+}
+
+.mapping-fail-lastseen:hover {
+    color: var(--accent);
+    text-decoration: underline;
+}
+
 .mapping-fail-meta.editing .mapping-fail-info {
     display: none;
 }

--- a/cloud/app/static/js/app.js
+++ b/cloud/app/static/js/app.js
@@ -693,17 +693,34 @@ function initInsights() {
             const data = await API.get("/api/insights/mapping-fails");
             const candidates = data.candidates || [];
             const windowDays = data.skip_window_days;
+            const lastfmUsername = data.lastfm_username || "";
 
             if (candidates.length === 0) {
                 container.innerHTML = `<p class="text-muted text-center">No mapping issues detected in the last ${windowDays} days.</p>`;
                 return;
             }
 
-            const fmtLastSeen = (ts) => {
-                if (!ts) return "";
-                const d = new Date(ts.endsWith("Z") ? ts : ts + "Z");
+            const parseLastSeen = (ts) => {
+                if (!ts) return null;
+                return new Date(ts.endsWith("Z") ? ts : ts + "Z");
+            };
+
+            const fmtLastSeen = (d) => {
+                if (!d) return "";
                 const pad = (n) => String(n).padStart(2, "0");
                 return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+            };
+
+            const fmtLocalDate = (d) => {
+                if (!d) return "";
+                const pad = (n) => String(n).padStart(2, "0");
+                return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+            };
+
+            const lastfmDayLink = (d) => {
+                if (!d || !lastfmUsername) return "";
+                const date = fmtLocalDate(d);
+                return `https://www.last.fm/user/${encodeURIComponent(lastfmUsername)}/library?from=${date}&rangetype=1day`;
             };
 
             const renderDefaultActions = (actions, ctx) => {
@@ -782,13 +799,18 @@ function initInsights() {
                 const breakdown = [];
                 if (c.no_scrobble_count > 0) breakdown.push(`${c.no_scrobble_count} no-scrobble`);
                 if (c.played_count > 0) breakdown.push(`${c.played_count} stale scrobble`);
-                const lastSeen = fmtLastSeen(c.last_seen);
+                const lastSeenDate = parseLastSeen(c.last_seen);
+                const lastSeen = fmtLastSeen(lastSeenDate);
+                const link = lastfmDayLink(lastSeenDate);
+                const lastSeenHtml = link
+                    ? `<a class="mapping-fail-info mapping-fail-lastseen" href="${escapeHtml(link)}" target="_blank" rel="noopener noreferrer" title="Open Last.fm scrobbles for this day">${escapeHtml(lastSeen)}</a>`
+                    : `<span class="text-muted mapping-fail-info">${escapeHtml(lastSeen)}</span>`;
                 const albumSuffix = c.album_name ? ` <span class="mapping-fail-album text-muted">(${escapeHtml(c.album_name)})</span>` : "";
                 return `
                     <div class="mapping-fail-row" data-idx="${i}">
                         <div class="mapping-fail-title">${escapeHtml(c.track_name)} — ${escapeHtml(c.artist_name)}${albumSuffix}</div>
                         <div class="mapping-fail-meta">
-                            <span class="text-muted mapping-fail-info">${lastSeen}</span>
+                            ${lastSeenHtml}
                             <span class="text-muted mapping-fail-info">${c.total_count}x (${breakdown.join(", ")})</span>
                             <div class="mapping-fail-actions"></div>
                         </div>


### PR DESCRIPTION
Each row in the Mapping issues card (Insights tab) now turns its local 'last seen' timestamp into a clickable link to that day's Last.fm scrobbles, so a mismatched scrobble title can be looked up and pasted into the Add alias input without manually navigating Last.fm.

## Changes
- cloud/app/routers/insights.py — /api/insights/mapping-fails now also returns lastfm_username (from the LASTFM_USERNAME env var)
- cloud/app/static/js/app.js — wrap last-seen timestamp in <a target="_blank"> with last.fm/user/<user>/library?from=YYYY-MM-DD&rangetype=1day; date is the locally-converted day shown to the user. Falls back to plain text when LASTFM_USERNAME is unset.
- cloud/app/static/css/style.css — muted color + accent/underline on hover
- cloud/app/__init__.py — bump to v3.11.0

## Verification
Deployed to VPS as v3.11.0-1, health check passed, user confirmed the link works on the live Insights tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)