### PR TITLE
Add 7-day per-artist chart to dashboard (v3.12.0)

### DIFF
--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.12.0-2"
+APP_VERSION = "v3.12.0-3"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.12.0-3"
+APP_VERSION = "v3.12.0-4"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.11.0"
+APP_VERSION = "v3.12.0-1"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.12.0-5"
+APP_VERSION = "v3.12.0-6"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.12.0"
+APP_VERSION = "v3.12.0-7"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.12.0-7"
+APP_VERSION = "v3.12.0"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.12.0-6"
+APP_VERSION = "v3.12.0"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.12.0-1"
+APP_VERSION = "v3.12.0-2"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.12.0-4"
+APP_VERSION = "v3.12.0-5"

--- a/cloud/app/artist_stats.py
+++ b/cloud/app/artist_stats.py
@@ -1,0 +1,115 @@
+"""Daily per-artist scrobble breakdown for the dashboard chart.
+
+Source: Last.fm scrobbles — the authoritative listening history — not the app's
+own `track_events`, which only capture skip-detection while the worker runs and
+would distort actual play counts (skipped tracks inflate, off-app plays vanish).
+
+Counts are per-artist scrobbles (plays) per local day, for the last
+WINDOW_DAYS full days, excluding today. Results are cached per (tz, end_date)
+since the data only changes once a day.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from app.lastfm_api import LASTFM_ERROR, get_recent_tracks
+
+logger = logging.getLogger(__name__)
+
+WINDOW_DAYS = 7
+TOP_ARTISTS = 6
+
+_cache: dict[str, dict] = {}
+
+
+def _resolve_tz(tz: str) -> ZoneInfo:
+    if tz:
+        try:
+            return ZoneInfo(tz)
+        except Exception:
+            logger.warning("[ArtistStats] Unknown tz %r — falling back to UTC", tz)
+    return ZoneInfo("UTC")
+
+
+async def get_artist_daily(tz: str = "") -> dict:
+    """Per-day, per-artist scrobble counts for the last WINDOW_DAYS full days.
+
+    Returns:
+      {
+        "start": "YYYY-MM-DD", "end": "YYYY-MM-DD",
+        "artists": [name, ...],            # global top artists, count desc
+        "days": [{"date", "counts": [int per top artist], "other", "total"}],
+        "error"?: str,                     # present only on Last.fm failure
+      }
+    """
+    zone = _resolve_tz(tz)
+    today = datetime.now(zone).date()
+    end_date = today - timedelta(days=1)  # last full day, inclusive
+    start_date = today - timedelta(days=WINDOW_DAYS)  # first full day, inclusive
+
+    cache_key = f"{zone.key}|{end_date.isoformat()}"
+    cached = _cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    # UTC window: [start 00:00 local, today 00:00 local)
+    start_local = datetime.combine(start_date, datetime.min.time(), tzinfo=zone)
+    end_local = datetime.combine(today, datetime.min.time(), tzinfo=zone)
+    from_uts = int(start_local.astimezone(timezone.utc).timestamp())
+    to_uts = int(end_local.astimezone(timezone.utc).timestamp()) - 1
+
+    scrobbles = await get_recent_tracks(from_uts, to_uts)
+    if scrobbles == LASTFM_ERROR:
+        # Don't cache transient failures.
+        return {
+            "start": start_date.isoformat(),
+            "end": end_date.isoformat(),
+            "artists": [],
+            "days": [],
+            "error": "Couldn't reach Last.fm.",
+        }
+
+    day_dates = [start_date + timedelta(days=i) for i in range(WINDOW_DAYS)]
+    per_day: dict[str, dict[str, int]] = {d.isoformat(): {} for d in day_dates}
+    total_by_artist: dict[str, int] = {}
+
+    for s in scrobbles:
+        local_date = datetime.fromtimestamp(s["uts"], tz=timezone.utc).astimezone(zone).date()
+        if local_date < start_date or local_date > end_date:
+            continue  # guard against boundary scrobbles outside the window
+        artist = s["artist"]
+        day_map = per_day[local_date.isoformat()]
+        day_map[artist] = day_map.get(artist, 0) + 1
+        total_by_artist[artist] = total_by_artist.get(artist, 0) + 1
+
+    # Global top artists (count desc, then name for stable ordering/colors).
+    top = sorted(total_by_artist.items(), key=lambda kv: (-kv[1], kv[0]))[:TOP_ARTISTS]
+    top_artists = [name for name, _ in top]
+    top_set = set(top_artists)
+
+    days = []
+    for d in day_dates:
+        day_map = per_day[d.isoformat()]
+        counts = [day_map.get(a, 0) for a in top_artists]
+        other = sum(c for a, c in day_map.items() if a not in top_set)
+        days.append(
+            {
+                "date": d.isoformat(),
+                "counts": counts,
+                "other": other,
+                "total": sum(day_map.values()),
+            }
+        )
+
+    result = {
+        "start": start_date.isoformat(),
+        "end": end_date.isoformat(),
+        "artists": top_artists,
+        "days": days,
+    }
+
+    if len(_cache) > 8:
+        _cache.clear()  # crude bound; keys roll daily, stale ones are harmless
+    _cache[cache_key] = result
+    return result

--- a/cloud/app/artist_stats.py
+++ b/cloud/app/artist_stats.py
@@ -5,8 +5,8 @@ own `track_events`, which only capture skip-detection while the worker runs and
 would distort actual play counts (skipped tracks inflate, off-app plays vanish).
 
 Counts are per-artist scrobbles (plays) per local day, for the last
-WINDOW_DAYS full days, excluding today. Results are cached per (tz, end_date)
-since the data only changes once a day.
+WINDOW_DAYS full days, excluding today, limited to the global top artists.
+Results are cached per (tz, end_date) since the data only changes once a day.
 """
 
 import logging
@@ -39,7 +39,7 @@ async def get_artist_daily(tz: str = "") -> dict:
       {
         "start": "YYYY-MM-DD", "end": "YYYY-MM-DD",
         "artists": [name, ...],            # global top artists, count desc
-        "days": [{"date", "counts": [int per top artist], "other", "total"}],
+        "days": [{"date", "counts": [int per top artist], "total"}],
         "error"?: str,                     # present only on Last.fm failure
       }
     """
@@ -86,19 +86,16 @@ async def get_artist_daily(tz: str = "") -> dict:
     # Global top artists (count desc, then name for stable ordering/colors).
     top = sorted(total_by_artist.items(), key=lambda kv: (-kv[1], kv[0]))[:TOP_ARTISTS]
     top_artists = [name for name, _ in top]
-    top_set = set(top_artists)
 
     days = []
     for d in day_dates:
         day_map = per_day[d.isoformat()]
         counts = [day_map.get(a, 0) for a in top_artists]
-        other = sum(c for a, c in day_map.items() if a not in top_set)
         days.append(
             {
                 "date": d.isoformat(),
                 "counts": counts,
-                "other": other,
-                "total": sum(day_map.values()),
+                "total": sum(counts),  # total across top artists only
             }
         )
 

--- a/cloud/app/lastfm_api.py
+++ b/cloud/app/lastfm_api.py
@@ -189,6 +189,83 @@ async def get_nowplaying(username: str = "") -> dict | None:
     return {"artist": artist_name, "name": name}
 
 
+# ── Recent tracks (read) ─────────────────────────────────────────
+
+
+async def get_recent_tracks(from_uts: int, to_uts: int, username: str = "") -> list[dict] | str:
+    """Return scrobbles with a UTS in [from_uts, to_uts], paginated.
+
+    Each entry: {"artist": str, "name": str, "uts": int}. The live nowplaying
+    entry (which has no `date`) is skipped. Returns LASTFM_ERROR on failure.
+    """
+    user = username or get_lastfm_username()
+    if not user:
+        return []
+    api_key = get_lastfm_api_key()
+    if not api_key:
+        return []
+
+    results: list[dict] = []
+    page = 1
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            while True:
+                r = await client.get(
+                    LASTFM_API_URL,
+                    params={
+                        "method": "user.getrecenttracks",
+                        "user": user,
+                        "api_key": api_key,
+                        "format": "json",
+                        "limit": 200,
+                        "page": page,
+                        "from": from_uts,
+                        "to": to_uts,
+                    },
+                )
+                if r.status_code != 200:
+                    logger.warning(
+                        "[Last.fm] getRecentTracks status %d: %s", r.status_code, r.text[:200]
+                    )
+                    return LASTFM_ERROR
+                data = r.json() or {}
+                rt = data.get("recenttracks", {})
+                tracks = rt.get("track", [])
+                if isinstance(tracks, dict):
+                    tracks = [tracks]
+                for t in tracks:
+                    attr = t.get("@attr") or {}
+                    if str(attr.get("nowplaying", "")).lower() == "true":
+                        continue  # live track, not a completed scrobble
+                    artist_obj = t.get("artist") or {}
+                    artist_name = (
+                        artist_obj.get("#text") if isinstance(artist_obj, dict) else str(artist_obj)
+                    )
+                    name = t.get("name", "")
+                    date_obj = t.get("date") or {}
+                    uts_raw = date_obj.get("uts") if isinstance(date_obj, dict) else None
+                    try:
+                        uts = int(uts_raw) if uts_raw else None
+                    except (ValueError, TypeError):
+                        uts = None
+                    if artist_name and name and uts is not None:
+                        results.append({"artist": artist_name, "name": name, "uts": uts})
+
+                attr = rt.get("@attr", {})
+                try:
+                    total_pages = int(attr.get("totalPages", 1))
+                except (ValueError, TypeError):
+                    total_pages = 1
+                if page >= total_pages:
+                    break
+                page += 1
+    except httpx.RequestError as e:
+        logger.warning("[Last.fm] Network error fetching recent tracks: %s", e)
+        return LASTFM_ERROR
+
+    return results
+
+
 # ── Loved tracks (read) ──────────────────────────────────────────
 
 

--- a/cloud/app/routers/insights.py
+++ b/cloud/app/routers/insights.py
@@ -5,6 +5,7 @@ Insights API routes.
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
+from app.artist_stats import get_artist_daily
 from app.config import get_lastfm_username, load_settings
 from app.database import (
     add_track_alias,
@@ -51,6 +52,12 @@ async def get_overall_insights(request: Request, tz: str = ""):
     insights = generate_insights_all(metrics, settings["skip_window_days"])
 
     return {"metrics": metrics, "insights": insights}
+
+
+@router.get("/artist-daily")
+async def artist_daily(request: Request, tz: str = ""):
+    """Per-day, per-artist scrobble counts for the last 7 full days (Last.fm)."""
+    return await get_artist_daily(tz)
 
 
 @router.get("/mapping-fails")

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -758,10 +758,24 @@ input:focus, select:focus {
 /* ── Artist chart (dashboard) ────────────────────── */
 
 .artist-chart {
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 6px;
+    width: 100%;
+}
+
+.artist-chart-svg {
+    display: block;
+    width: 100%;
+    height: auto;
+    overflow: visible;
+}
+
+.artist-chart-grid {
+    stroke: var(--border-secondary);
+    stroke-width: 1;
+}
+
+.artist-chart-axis {
+    fill: var(--text-muted);
+    font-size: 11px;
 }
 
 .artist-chart-empty {
@@ -769,41 +783,6 @@ input:focus, select:focus {
     text-align: center;
     padding: 56px 0;
     font-size: 0.85rem;
-}
-
-.artist-chart-col {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4px;
-    min-width: 0;
-}
-
-.artist-chart-total {
-    font-size: 0.7rem;
-    color: var(--text-muted);
-    min-height: 1em;
-    line-height: 1;
-}
-
-.artist-chart-bar {
-    width: 100%;
-    max-width: 36px;
-    display: flex;
-    flex-direction: column-reverse;
-    justify-content: flex-start;
-    border-radius: 4px;
-    overflow: hidden;
-    background: var(--bg-input);
-}
-
-.artist-chart-seg { width: 100%; }
-
-.artist-chart-label {
-    font-size: 0.7rem;
-    color: var(--text-secondary);
-    white-space: nowrap;
 }
 
 .artist-chart-legend {

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -761,7 +761,7 @@ input:focus, select:focus {
     display: flex;
     align-items: flex-end;
     justify-content: space-between;
-    gap: 6px;
+    gap: 3px;
 }
 
 .artist-chart-col {
@@ -782,7 +782,7 @@ input:focus, select:focus {
 
 .artist-chart-bar {
     width: 100%;
-    max-width: 40px;
+    max-width: 64px;
     display: flex;
     flex-direction: column-reverse;
     border-radius: 4px;

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -760,6 +760,7 @@ input:focus, select:focus {
 .dashboard-grid {
     display: flex;
     flex-direction: column;
+    gap: 12px;
 }
 
 @media (min-width: 820px) {

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -758,24 +758,54 @@ input:focus, select:focus {
 /* ── Artist chart (dashboard) ────────────────────── */
 
 .artist-chart {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 6px;
+}
+
+.artist-chart-col {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+
+.artist-chart-total {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    min-height: 1em;
+    line-height: 1;
+}
+
+.artist-chart-bar {
     width: 100%;
+    max-width: 40px;
+    display: flex;
+    flex-direction: column-reverse;
+    border-radius: 4px;
+    overflow: hidden;
+    background: var(--bg-input);
 }
 
-.artist-chart-svg {
-    display: block;
+.artist-chart-seg {
     width: 100%;
-    height: auto;
-    overflow: visible;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #fff;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.55);
+    overflow: hidden;
 }
 
-.artist-chart-grid {
-    stroke: var(--border-secondary);
-    stroke-width: 1;
-}
-
-.artist-chart-axis {
-    fill: var(--text-muted);
-    font-size: 11px;
+.artist-chart-label {
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+    white-space: nowrap;
 }
 
 .artist-chart-empty {

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -755,6 +755,82 @@ input:focus, select:focus {
     padding: 16px 0;
 }
 
+/* ── Artist chart (dashboard) ────────────────────── */
+
+.artist-chart {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 6px;
+}
+
+.artist-chart-empty {
+    width: 100%;
+    text-align: center;
+    padding: 56px 0;
+    font-size: 0.85rem;
+}
+
+.artist-chart-col {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+}
+
+.artist-chart-total {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    min-height: 1em;
+    line-height: 1;
+}
+
+.artist-chart-bar {
+    width: 100%;
+    max-width: 36px;
+    display: flex;
+    flex-direction: column-reverse;
+    justify-content: flex-start;
+    border-radius: 4px;
+    overflow: hidden;
+    background: var(--bg-input);
+}
+
+.artist-chart-seg { width: 100%; }
+
+.artist-chart-label {
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+    white-space: nowrap;
+}
+
+.artist-chart-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+    justify-content: center;
+    margin-top: 14px;
+}
+
+.artist-chart-legend:empty { margin-top: 0; }
+
+.artist-chart-legend-item {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+.artist-chart-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    flex-shrink: 0;
+}
+
 /* ── Toast ───────────────────────────────────────── */
 
 .toast {

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -763,19 +763,36 @@ input:focus, select:focus {
     gap: 12px;
 }
 
+/* Chart hidden by default; revealed via the toggle (adds .chart-open). */
+.dashboard-side { display: none; }
+.container-wide.chart-open .dashboard-side { display: block; }
+
+.chart-toggle {
+    display: block;
+    margin: 4px auto 0;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    padding: 4px 8px;
+    cursor: pointer;
+}
+
+.chart-toggle:hover { color: var(--text-secondary); }
+
 @media (min-width: 820px) {
-    .container-wide { max-width: 1040px; }
-    .dashboard-grid {
+    .container-wide.chart-open { max-width: 1040px; }
+    .container-wide.chart-open .dashboard-grid {
         flex-direction: row;
         align-items: flex-start;
         gap: 16px;
     }
-    .dashboard-main { flex: 0 0 380px; }
-    .dashboard-side {
+    .container-wide.chart-open .dashboard-main { flex: 0 0 380px; }
+    .container-wide.chart-open .dashboard-side {
         flex: 1 1 auto;
         min-width: 0;
     }
-    .dashboard-side .card { margin-bottom: 0; }
+    .container-wide.chart-open .dashboard-side .card { margin-bottom: 0; }
 }
 
 /* ── Artist chart (dashboard) ────────────────────── */

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -755,6 +755,28 @@ input:focus, select:focus {
     padding: 16px 0;
 }
 
+/* ── Dashboard layout (chart beside Now Playing) ─── */
+
+.dashboard-grid {
+    display: flex;
+    flex-direction: column;
+}
+
+@media (min-width: 820px) {
+    .container-wide { max-width: 1040px; }
+    .dashboard-grid {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 16px;
+    }
+    .dashboard-main { flex: 0 0 380px; }
+    .dashboard-side {
+        flex: 1 1 auto;
+        min-width: 0;
+    }
+    .dashboard-side .card { margin-bottom: 0; }
+}
+
 /* ── Artist chart (dashboard) ────────────────────── */
 
 .artist-chart {

--- a/cloud/app/static/js/app.js
+++ b/cloud/app/static/js/app.js
@@ -1181,9 +1181,12 @@ function initArtistChart() {
     if (!chart) return; // Not on dashboard
 
     const COLORS = ["#1DB954", "#60a5fa", "#fb923c", "#c084fc", "#f87171", "#4ade80"];
-    const OTHER_COLOR = "#4b5563";
-    const CHART_HEIGHT = 140; // px — plot area for the tallest day
+    const HEIGHT = 180; // px
+    const PAD = { top: 14, right: 12, bottom: 24, left: 30 };
+    const SVG_NS = "http://www.w3.org/2000/svg";
     const tz = encodeURIComponent(Intl.DateTimeFormat().resolvedOptions().timeZone);
+
+    let lastData = null; // cached payload so resize can re-render without refetch
 
     function weekday(dateStr) {
         const d = new Date(dateStr + "T00:00:00");
@@ -1193,6 +1196,113 @@ function initArtistChart() {
     function showMessage(msg) {
         chart.innerHTML = `<div class="artist-chart-empty text-muted">${escapeHtml(msg)}</div>`;
         if (legendEl) legendEl.innerHTML = "";
+    }
+
+    function svgEl(name, attrs) {
+        const el = document.createElementNS(SVG_NS, name);
+        for (const k in attrs) el.setAttribute(k, attrs[k]);
+        return el;
+    }
+
+    // "Nice" axis maximum so y gridlines land on round numbers.
+    function niceMax(value) {
+        if (value <= 4) return Math.max(1, value);
+        const pow = Math.pow(10, Math.floor(Math.log10(value)));
+        for (const m of [1, 2, 2.5, 5, 10]) {
+            const step = m * pow;
+            if (Math.ceil(value / step) * step >= value) {
+                const candidate = Math.ceil(value / step) * step;
+                if (candidate >= value) return candidate;
+            }
+        }
+        return value;
+    }
+
+    function render() {
+        const data = lastData;
+        if (!data) return;
+        const artists = data.artists || [];
+        const days = data.days || [];
+
+        const width = Math.max(260, chart.clientWidth || 320);
+        const plotW = width - PAD.left - PAD.right;
+        const plotH = HEIGHT - PAD.top - PAD.bottom;
+        const n = days.length;
+
+        const rawMax = Math.max(1, ...days.flatMap(d => d.counts));
+        const yMax = niceMax(rawMax);
+        const x = i => PAD.left + (n <= 1 ? plotW / 2 : (plotW * i) / (n - 1));
+        const y = v => PAD.top + plotH * (1 - v / yMax);
+
+        const svg = svgEl("svg", {
+            class: "artist-chart-svg",
+            viewBox: `0 0 ${width} ${HEIGHT}`,
+            width: width,
+            height: HEIGHT,
+            role: "img",
+        });
+
+        // Horizontal gridlines + y labels (0 and yMax, plus midpoint when even).
+        const yTicks = yMax % 2 === 0 ? [0, yMax / 2, yMax] : [0, yMax];
+        yTicks.forEach(t => {
+            svg.appendChild(svgEl("line", {
+                x1: PAD.left, y1: y(t), x2: width - PAD.right, y2: y(t),
+                class: "artist-chart-grid",
+            }));
+            const label = svgEl("text", {
+                x: PAD.left - 6, y: y(t) + 3, class: "artist-chart-axis", "text-anchor": "end",
+            });
+            label.textContent = t;
+            svg.appendChild(label);
+        });
+
+        // X labels (weekday under each point).
+        days.forEach((d, i) => {
+            const label = svgEl("text", {
+                x: x(i), y: HEIGHT - 8, class: "artist-chart-axis", "text-anchor": "middle",
+            });
+            label.textContent = weekday(d.date);
+            label.appendChild(svgEl("title", {})).textContent = d.date;
+            svg.appendChild(label);
+        });
+
+        // One line + points per artist.
+        artists.forEach((name, ai) => {
+            const color = COLORS[ai % COLORS.length];
+            const pts = days.map((d, i) => `${x(i)},${y(d.counts[ai] || 0)}`).join(" ");
+            svg.appendChild(svgEl("polyline", {
+                points: pts, fill: "none", stroke: color, "stroke-width": 2,
+                "stroke-linejoin": "round", "stroke-linecap": "round",
+            }));
+            days.forEach((d, i) => {
+                const c = d.counts[ai] || 0;
+                const dot = svgEl("circle", { cx: x(i), cy: y(c), r: 2.5, fill: color });
+                const title = svgEl("title", {});
+                title.textContent = `${name}: ${c} on ${d.date}`;
+                dot.appendChild(title);
+                svg.appendChild(dot);
+            });
+        });
+
+        chart.innerHTML = "";
+        chart.appendChild(svg);
+
+        // Legend
+        if (legendEl) {
+            legendEl.innerHTML = "";
+            artists.forEach((name, i) => {
+                const li = document.createElement("div");
+                li.className = "artist-chart-legend-item";
+                const swatch = document.createElement("span");
+                swatch.className = "artist-chart-swatch";
+                swatch.style.background = COLORS[i % COLORS.length];
+                const span = document.createElement("span");
+                span.textContent = name;
+                li.appendChild(swatch);
+                li.appendChild(span);
+                legendEl.appendChild(li);
+            });
+        }
     }
 
     async function load() {
@@ -1207,76 +1317,20 @@ function initArtistChart() {
             showMessage(data.error);
             return;
         }
-
-        const artists = data.artists || [];
-        const days = data.days || [];
-        if (!days.some(d => d.total > 0)) {
+        if (!(data.artists || []).length || !(data.days || []).some(d => d.total > 0)) {
             showMessage("No scrobbles in the last 7 days.");
             return;
         }
-
-        const maxTotal = Math.max(1, ...days.map(d => d.total));
-        chart.innerHTML = "";
-
-        days.forEach(day => {
-            const col = document.createElement("div");
-            col.className = "artist-chart-col";
-
-            const total = document.createElement("div");
-            total.className = "artist-chart-total";
-            total.textContent = day.total > 0 ? day.total : "";
-
-            const bar = document.createElement("div");
-            bar.className = "artist-chart-bar";
-            bar.style.height = `${CHART_HEIGHT}px`;
-
-            // Segments bottom→top (column-reverse): top artists in order, then Other.
-            const segs = [];
-            artists.forEach((name, i) => {
-                const c = day.counts[i] || 0;
-                if (c > 0) segs.push({ name, count: c, color: COLORS[i % COLORS.length] });
-            });
-            if (day.other > 0) segs.push({ name: "Other", count: day.other, color: OTHER_COLOR });
-
-            segs.forEach(s => {
-                const seg = document.createElement("div");
-                seg.className = "artist-chart-seg";
-                seg.style.height = `${(s.count / maxTotal) * CHART_HEIGHT}px`;
-                seg.style.background = s.color;
-                seg.title = `${s.name}: ${s.count} on ${day.date}`;
-                bar.appendChild(seg);
-            });
-
-            const label = document.createElement("div");
-            label.className = "artist-chart-label";
-            label.textContent = weekday(day.date);
-            label.title = day.date;
-
-            col.appendChild(total);
-            col.appendChild(bar);
-            col.appendChild(label);
-            chart.appendChild(col);
-        });
-
-        // Legend
-        if (legendEl) {
-            legendEl.innerHTML = "";
-            const items = artists.map((name, i) => ({ name, color: COLORS[i % COLORS.length] }));
-            if (days.some(d => d.other > 0)) items.push({ name: "Other", color: OTHER_COLOR });
-            items.forEach(item => {
-                const li = document.createElement("div");
-                li.className = "artist-chart-legend-item";
-                const swatch = document.createElement("span");
-                swatch.className = "artist-chart-swatch";
-                swatch.style.background = item.color;
-                const span = document.createElement("span");
-                span.textContent = item.name;
-                li.appendChild(swatch);
-                li.appendChild(span);
-                legendEl.appendChild(li);
-            });
-        }
+        lastData = data;
+        render();
     }
+
+    // Re-render on resize (debounced) so the SVG stays crisp at any width.
+    let resizeTimer = null;
+    window.addEventListener("resize", () => {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(() => { if (lastData) render(); }, 150);
+    });
 
     load();
 }

--- a/cloud/app/static/js/app.js
+++ b/cloud/app/static/js/app.js
@@ -1173,6 +1173,115 @@ function initLogs() {
 }
 
 
+// ── Artist chart (dashboard) ────────────────────────────────────
+
+function initArtistChart() {
+    const chart = document.getElementById("artist-chart");
+    const legendEl = document.getElementById("artist-chart-legend");
+    if (!chart) return; // Not on dashboard
+
+    const COLORS = ["#1DB954", "#60a5fa", "#fb923c", "#c084fc", "#f87171", "#4ade80"];
+    const OTHER_COLOR = "#4b5563";
+    const CHART_HEIGHT = 140; // px — plot area for the tallest day
+    const tz = encodeURIComponent(Intl.DateTimeFormat().resolvedOptions().timeZone);
+
+    function weekday(dateStr) {
+        const d = new Date(dateStr + "T00:00:00");
+        return d.toLocaleDateString([], { weekday: "short" });
+    }
+
+    function showMessage(msg) {
+        chart.innerHTML = `<div class="artist-chart-empty text-muted">${escapeHtml(msg)}</div>`;
+        if (legendEl) legendEl.innerHTML = "";
+    }
+
+    async function load() {
+        let data;
+        try {
+            data = await API.get(`/api/insights/artist-daily?tz=${tz}`);
+        } catch {
+            showMessage("Failed to load chart.");
+            return;
+        }
+        if (data.error) {
+            showMessage(data.error);
+            return;
+        }
+
+        const artists = data.artists || [];
+        const days = data.days || [];
+        if (!days.some(d => d.total > 0)) {
+            showMessage("No scrobbles in the last 7 days.");
+            return;
+        }
+
+        const maxTotal = Math.max(1, ...days.map(d => d.total));
+        chart.innerHTML = "";
+
+        days.forEach(day => {
+            const col = document.createElement("div");
+            col.className = "artist-chart-col";
+
+            const total = document.createElement("div");
+            total.className = "artist-chart-total";
+            total.textContent = day.total > 0 ? day.total : "";
+
+            const bar = document.createElement("div");
+            bar.className = "artist-chart-bar";
+            bar.style.height = `${CHART_HEIGHT}px`;
+
+            // Segments bottom→top (column-reverse): top artists in order, then Other.
+            const segs = [];
+            artists.forEach((name, i) => {
+                const c = day.counts[i] || 0;
+                if (c > 0) segs.push({ name, count: c, color: COLORS[i % COLORS.length] });
+            });
+            if (day.other > 0) segs.push({ name: "Other", count: day.other, color: OTHER_COLOR });
+
+            segs.forEach(s => {
+                const seg = document.createElement("div");
+                seg.className = "artist-chart-seg";
+                seg.style.height = `${(s.count / maxTotal) * CHART_HEIGHT}px`;
+                seg.style.background = s.color;
+                seg.title = `${s.name}: ${s.count} on ${day.date}`;
+                bar.appendChild(seg);
+            });
+
+            const label = document.createElement("div");
+            label.className = "artist-chart-label";
+            label.textContent = weekday(day.date);
+            label.title = day.date;
+
+            col.appendChild(total);
+            col.appendChild(bar);
+            col.appendChild(label);
+            chart.appendChild(col);
+        });
+
+        // Legend
+        if (legendEl) {
+            legendEl.innerHTML = "";
+            const items = artists.map((name, i) => ({ name, color: COLORS[i % COLORS.length] }));
+            if (days.some(d => d.other > 0)) items.push({ name: "Other", color: OTHER_COLOR });
+            items.forEach(item => {
+                const li = document.createElement("div");
+                li.className = "artist-chart-legend-item";
+                const swatch = document.createElement("span");
+                swatch.className = "artist-chart-swatch";
+                swatch.style.background = item.color;
+                const span = document.createElement("span");
+                span.textContent = item.name;
+                li.appendChild(swatch);
+                li.appendChild(span);
+                legendEl.appendChild(li);
+            });
+        }
+    }
+
+    load();
+}
+
+
 // ── Utilities ───────────────────────────────────────────────────
 
 function escapeHtml(text) {
@@ -1186,6 +1295,7 @@ function escapeHtml(text) {
 
 document.addEventListener("DOMContentLoaded", () => {
     initDashboard();
+    initArtistChart();
     initSettings();
     initArtists();
     initInsights();

--- a/cloud/app/static/js/app.js
+++ b/cloud/app/static/js/app.js
@@ -1178,12 +1178,17 @@ function initLogs() {
 function initArtistChart() {
     const chart = document.getElementById("artist-chart");
     const legendEl = document.getElementById("artist-chart-legend");
-    if (!chart) return; // Not on dashboard
+    const toggleBtn = document.getElementById("chart-toggle");
+    if (!chart || !toggleBtn) return; // Not on dashboard
 
+    const container = chart.closest(".container");
+    const STORE_KEY = "artistChartVisible";
     const COLORS = ["#1DB954", "#60a5fa", "#fb923c", "#c084fc", "#f87171", "#4ade80"];
     const BAR_HEIGHT = 170; // px — full bar = 100% of that day's plays
     const LABEL_MIN = 15; // min segment height (px) to show the play count inside
     const tz = encodeURIComponent(Intl.DateTimeFormat().resolvedOptions().timeZone);
+
+    let loaded = false; // fetch lazily, only once the chart is first revealed
 
     function weekday(dateStr) {
         const d = new Date(dateStr + "T00:00:00");
@@ -1273,7 +1278,24 @@ function initArtistChart() {
         }
     }
 
-    load();
+    function setOpen(open) {
+        if (container) container.classList.toggle("chart-open", open);
+        toggleBtn.textContent = open ? "Hide artist chart" : "Show artist chart";
+        toggleBtn.setAttribute("aria-expanded", open ? "true" : "false");
+        try { localStorage.setItem(STORE_KEY, open ? "1" : "0"); } catch { /* ignore */ }
+        if (open && !loaded) {
+            loaded = true;
+            load();
+        }
+    }
+
+    toggleBtn.addEventListener("click", () => {
+        setOpen(!(container && container.classList.contains("chart-open")));
+    });
+
+    let initialOpen = false;
+    try { initialOpen = localStorage.getItem(STORE_KEY) === "1"; } catch { /* ignore */ }
+    setOpen(initialOpen);
 }
 
 

--- a/cloud/app/static/js/app.js
+++ b/cloud/app/static/js/app.js
@@ -1181,12 +1181,9 @@ function initArtistChart() {
     if (!chart) return; // Not on dashboard
 
     const COLORS = ["#1DB954", "#60a5fa", "#fb923c", "#c084fc", "#f87171", "#4ade80"];
-    const HEIGHT = 180; // px
-    const PAD = { top: 14, right: 12, bottom: 24, left: 30 };
-    const SVG_NS = "http://www.w3.org/2000/svg";
+    const BAR_HEIGHT = 170; // px — full bar = 100% of that day's plays
+    const LABEL_MIN = 15; // min segment height (px) to show the play count inside
     const tz = encodeURIComponent(Intl.DateTimeFormat().resolvedOptions().timeZone);
-
-    let lastData = null; // cached payload so resize can re-render without refetch
 
     function weekday(dateStr) {
         const d = new Date(dateStr + "T00:00:00");
@@ -1198,94 +1195,65 @@ function initArtistChart() {
         if (legendEl) legendEl.innerHTML = "";
     }
 
-    function svgEl(name, attrs) {
-        const el = document.createElementNS(SVG_NS, name);
-        for (const k in attrs) el.setAttribute(k, attrs[k]);
-        return el;
-    }
-
-    // "Nice" axis maximum so y gridlines land on round numbers.
-    function niceMax(value) {
-        if (value <= 4) return Math.max(1, value);
-        const pow = Math.pow(10, Math.floor(Math.log10(value)));
-        for (const m of [1, 2, 2.5, 5, 10]) {
-            const step = m * pow;
-            if (Math.ceil(value / step) * step >= value) {
-                const candidate = Math.ceil(value / step) * step;
-                if (candidate >= value) return candidate;
-            }
+    async function load() {
+        let data;
+        try {
+            data = await API.get(`/api/insights/artist-daily?tz=${tz}`);
+        } catch {
+            showMessage("Failed to load chart.");
+            return;
         }
-        return value;
-    }
-
-    function render() {
-        const data = lastData;
-        if (!data) return;
+        if (data.error) {
+            showMessage(data.error);
+            return;
+        }
         const artists = data.artists || [];
         const days = data.days || [];
-
-        const width = Math.max(260, chart.clientWidth || 320);
-        const plotW = width - PAD.left - PAD.right;
-        const plotH = HEIGHT - PAD.top - PAD.bottom;
-        const n = days.length;
-
-        const rawMax = Math.max(1, ...days.flatMap(d => d.counts));
-        const yMax = niceMax(rawMax);
-        const x = i => PAD.left + (n <= 1 ? plotW / 2 : (plotW * i) / (n - 1));
-        const y = v => PAD.top + plotH * (1 - v / yMax);
-
-        const svg = svgEl("svg", {
-            class: "artist-chart-svg",
-            viewBox: `0 0 ${width} ${HEIGHT}`,
-            width: width,
-            height: HEIGHT,
-            role: "img",
-        });
-
-        // Horizontal gridlines + y labels (0 and yMax, plus midpoint when even).
-        const yTicks = yMax % 2 === 0 ? [0, yMax / 2, yMax] : [0, yMax];
-        yTicks.forEach(t => {
-            svg.appendChild(svgEl("line", {
-                x1: PAD.left, y1: y(t), x2: width - PAD.right, y2: y(t),
-                class: "artist-chart-grid",
-            }));
-            const label = svgEl("text", {
-                x: PAD.left - 6, y: y(t) + 3, class: "artist-chart-axis", "text-anchor": "end",
-            });
-            label.textContent = t;
-            svg.appendChild(label);
-        });
-
-        // X labels (weekday under each point).
-        days.forEach((d, i) => {
-            const label = svgEl("text", {
-                x: x(i), y: HEIGHT - 8, class: "artist-chart-axis", "text-anchor": "middle",
-            });
-            label.textContent = weekday(d.date);
-            label.appendChild(svgEl("title", {})).textContent = d.date;
-            svg.appendChild(label);
-        });
-
-        // One line + points per artist.
-        artists.forEach((name, ai) => {
-            const color = COLORS[ai % COLORS.length];
-            const pts = days.map((d, i) => `${x(i)},${y(d.counts[ai] || 0)}`).join(" ");
-            svg.appendChild(svgEl("polyline", {
-                points: pts, fill: "none", stroke: color, "stroke-width": 2,
-                "stroke-linejoin": "round", "stroke-linecap": "round",
-            }));
-            days.forEach((d, i) => {
-                const c = d.counts[ai] || 0;
-                const dot = svgEl("circle", { cx: x(i), cy: y(c), r: 2.5, fill: color });
-                const title = svgEl("title", {});
-                title.textContent = `${name}: ${c} on ${d.date}`;
-                dot.appendChild(title);
-                svg.appendChild(dot);
-            });
-        });
+        if (!artists.length || !days.some(d => d.total > 0)) {
+            showMessage("No scrobbles in the last 7 days.");
+            return;
+        }
 
         chart.innerHTML = "";
-        chart.appendChild(svg);
+        days.forEach(day => {
+            const dayTotal = day.total; // sum across top artists this day
+            const col = document.createElement("div");
+            col.className = "artist-chart-col";
+
+            const total = document.createElement("div");
+            total.className = "artist-chart-total";
+            total.textContent = dayTotal > 0 ? dayTotal : "";
+
+            const bar = document.createElement("div");
+            bar.className = "artist-chart-bar";
+            bar.style.height = `${BAR_HEIGHT}px`;
+
+            // Each bar fills to 100%: segment = artist's share of the day's plays.
+            // Segments stack bottom→top (column-reverse) in top-artist order.
+            artists.forEach((name, i) => {
+                const c = day.counts[i] || 0;
+                if (c <= 0) return;
+                const share = c / dayTotal;
+                const h = share * BAR_HEIGHT;
+                const seg = document.createElement("div");
+                seg.className = "artist-chart-seg";
+                seg.style.height = `${h}px`;
+                seg.style.background = COLORS[i % COLORS.length];
+                seg.title = `${name}: ${c} (${Math.round(share * 100)}%) on ${day.date}`;
+                if (h >= LABEL_MIN) seg.textContent = c; // show count only if it fits
+                bar.appendChild(seg);
+            });
+
+            const label = document.createElement("div");
+            label.className = "artist-chart-label";
+            label.textContent = weekday(day.date);
+            label.title = day.date;
+
+            col.appendChild(total);
+            col.appendChild(bar);
+            col.appendChild(label);
+            chart.appendChild(col);
+        });
 
         // Legend
         if (legendEl) {
@@ -1304,33 +1272,6 @@ function initArtistChart() {
             });
         }
     }
-
-    async function load() {
-        let data;
-        try {
-            data = await API.get(`/api/insights/artist-daily?tz=${tz}`);
-        } catch {
-            showMessage("Failed to load chart.");
-            return;
-        }
-        if (data.error) {
-            showMessage(data.error);
-            return;
-        }
-        if (!(data.artists || []).length || !(data.days || []).some(d => d.total > 0)) {
-            showMessage("No scrobbles in the last 7 days.");
-            return;
-        }
-        lastData = data;
-        render();
-    }
-
-    // Re-render on resize (debounced) so the SVG stays crisp at any width.
-    let resizeTimer = null;
-    window.addEventListener("resize", () => {
-        clearTimeout(resizeTimer);
-        resizeTimer = setTimeout(() => { if (lastData) render(); }, 150);
-    });
 
     load();
 }

--- a/cloud/app/templates/index.html
+++ b/cloud/app/templates/index.html
@@ -1,34 +1,40 @@
 {% extends "base.html" %}
 {% block title %}Dashboard - Spotify Auto-Skipper{% endblock %}
 {% block content %}
-<div class="container">
-    <div class="card now-playing">
-        <div id="last-checked-time" class="last-checked-time">&nbsp;</div>
-        <div id="next-check" class="next-check">&nbsp;</div>
-        <img id="album-art" class="album-art hidden" src="" alt="">
-        <div id="track-info" class="hidden">
-            <div id="track-name" class="track-name"></div>
-            <div id="artist-name" class="artist-name"></div>
-            <div id="last-check" class="last-check"></div>
-        </div>
-        <div id="nothing-playing" class="nothing-playing">Nothing is playing</div>
-        <div id="status-badge" class="status-badge offline">Connecting...</div>
-    </div>
+<div class="container container-wide">
+    <div class="dashboard-grid">
+        <div class="dashboard-main">
+            <div class="card now-playing">
+                <div id="last-checked-time" class="last-checked-time">&nbsp;</div>
+                <div id="next-check" class="next-check">&nbsp;</div>
+                <img id="album-art" class="album-art hidden" src="" alt="">
+                <div id="track-info" class="hidden">
+                    <div id="track-name" class="track-name"></div>
+                    <div id="artist-name" class="artist-name"></div>
+                    <div id="last-check" class="last-check"></div>
+                </div>
+                <div id="nothing-playing" class="nothing-playing">Nothing is playing</div>
+                <div id="status-badge" class="status-badge offline">Connecting...</div>
+            </div>
 
-    <div class="btn-group">
-        <button id="pause-btn" class="btn btn-full">Pause Skipping</button>
-        <button id="skip-one-pause-btn" class="btn btn-full">Don't Skip This Song</button>
-        <button id="like-btn" class="btn btn-full" disabled>Add to Liked Songs</button>
-        <button id="check-now-btn" class="btn btn-accent btn-full">Check Now</button>
-        <button id="remove-from-playlist-btn" class="btn btn-danger btn-full" disabled>Remove from Playlist</button>
-    </div>
-
-    <div class="card artist-chart-card">
-        <div class="card-title">Last 7 days by artist</div>
-        <div id="artist-chart" class="artist-chart">
-            <div class="artist-chart-empty text-muted">Loading…</div>
+            <div class="btn-group">
+                <button id="pause-btn" class="btn btn-full">Pause Skipping</button>
+                <button id="skip-one-pause-btn" class="btn btn-full">Don't Skip This Song</button>
+                <button id="like-btn" class="btn btn-full" disabled>Add to Liked Songs</button>
+                <button id="check-now-btn" class="btn btn-accent btn-full">Check Now</button>
+                <button id="remove-from-playlist-btn" class="btn btn-danger btn-full" disabled>Remove from Playlist</button>
+            </div>
         </div>
-        <div id="artist-chart-legend" class="artist-chart-legend"></div>
+
+        <div class="dashboard-side">
+            <div class="card artist-chart-card">
+                <div class="card-title">Last 7 days by artist</div>
+                <div id="artist-chart" class="artist-chart">
+                    <div class="artist-chart-empty text-muted">Loading…</div>
+                </div>
+                <div id="artist-chart-legend" class="artist-chart-legend"></div>
+            </div>
+        </div>
     </div>
 
     <div class="version-text"><a href="https://github.com/Vatroslav/spotify-auto-skipper" target="_blank" rel="noopener">{{ version }}</a></div>

--- a/cloud/app/templates/index.html
+++ b/cloud/app/templates/index.html
@@ -24,6 +24,8 @@
                 <button id="check-now-btn" class="btn btn-accent btn-full">Check Now</button>
                 <button id="remove-from-playlist-btn" class="btn btn-danger btn-full" disabled>Remove from Playlist</button>
             </div>
+
+            <button id="chart-toggle" class="chart-toggle" aria-expanded="false">Show artist chart</button>
         </div>
 
         <div class="dashboard-side">

--- a/cloud/app/templates/index.html
+++ b/cloud/app/templates/index.html
@@ -23,6 +23,14 @@
         <button id="remove-from-playlist-btn" class="btn btn-danger btn-full" disabled>Remove from Playlist</button>
     </div>
 
+    <div class="card artist-chart-card">
+        <div class="card-title">Last 7 days by artist</div>
+        <div id="artist-chart" class="artist-chart">
+            <div class="artist-chart-empty text-muted">Loading…</div>
+        </div>
+        <div id="artist-chart-legend" class="artist-chart-legend"></div>
+    </div>
+
     <div class="version-text"><a href="https://github.com/Vatroslav/spotify-auto-skipper" target="_blank" rel="noopener">{{ version }}</a></div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
Adds an optional **"Last 7 days by artist"** chart to the Now Playing dashboard.

- **Source:** Last.fm scrobbles (`user.getRecentTracks`), the authoritative listening history — not the app's own `track_events`, which only capture skip-detection.
- **Chart:** 100%-stacked bars, one per day (last 7 full days, excluding today). Each bar is composed of the global **top 6 artists** across the window (stable colour per artist), with the play count shown inside a segment when it fits; day total above each bar; hover shows artist/count/percentage.
- **Hidden by default:** a light "Show artist chart" toggle under the buttons. State persists in localStorage and the Last.fm fetch is lazy (only on first reveal).
- **Layout:** two-column on desktop (chart beside Now Playing), stacks below on mobile — only when the chart is open.
- Result cached per (timezone, end_date); fetched at most once a day.

## New
- `lastfm_api.get_recent_tracks()` — paginated scrobble fetch over a UTS window
- `artist_stats.get_artist_daily()` — local-day bucketing, global top-N, caching
- `GET /api/insights/artist-daily`

🤖 Generated with [Claude Code](https://claude.com/claude-code)