### PR TITLE
Per-artist never-skip toggle (#54)

### DIFF
--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.15.0-3"
+APP_VERSION = "v3.15.0"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.15.0-1"
+APP_VERSION = "v3.15.0-2"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.15.0-2"
+APP_VERSION = "v3.15.0-3"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.14.1"
+APP_VERSION = "v3.15.0-1"

--- a/cloud/app/database.py
+++ b/cloud/app/database.py
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS never_skip_artists (
     id        TEXT PRIMARY KEY,
     name      TEXT NOT NULL,
     image_url TEXT DEFAULT '',
+    enabled   INTEGER NOT NULL DEFAULT 1,
     added_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -133,11 +134,13 @@ async def init_db():
     try:
         await db.executescript(_CREATE_TABLES)
 
-        # Migrate: add image_url column if missing
+        # Migrate: add image_url / enabled columns if missing
         cursor = await db.execute("PRAGMA table_info(never_skip_artists)")
         columns = {row[1] for row in await cursor.fetchall()}
         if "image_url" not in columns:
             await db.execute("ALTER TABLE never_skip_artists ADD COLUMN image_url TEXT DEFAULT ''")
+        if "enabled" not in columns:
+            await db.execute("ALTER TABLE never_skip_artists ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1")
 
         # Migrate: add album_name to track_events
         cursor = await db.execute("PRAGMA table_info(track_events)")
@@ -420,7 +423,9 @@ async def set_many_settings(settings: dict):
 async def get_never_skip_artists() -> list[dict]:
     db = await get_db()
     try:
-        cursor = await db.execute("SELECT id, name, image_url, added_at FROM never_skip_artists ORDER BY name")
+        cursor = await db.execute(
+            "SELECT id, name, image_url, enabled, added_at FROM never_skip_artists ORDER BY name"
+        )
         rows = await cursor.fetchall()
         return [dict(row) for row in rows]
     finally:
@@ -448,6 +453,20 @@ async def remove_never_skip_artist(artist_id: str):
         await db.close()
 
 
+async def set_never_skip_artist_enabled(artist_id: str, enabled: bool) -> bool:
+    """Toggle whether an artist's never-skip protection is active. Returns True if a row was updated."""
+    db = await get_db()
+    try:
+        cursor = await db.execute(
+            "UPDATE never_skip_artists SET enabled = ? WHERE id = ?",
+            (1 if enabled else 0, artist_id),
+        )
+        await db.commit()
+        return cursor.rowcount > 0
+    finally:
+        await db.close()
+
+
 async def is_artist_never_skipped(artist_ids: list[str]) -> bool:
     if not artist_ids:
         return False
@@ -455,7 +474,7 @@ async def is_artist_never_skipped(artist_ids: list[str]) -> bool:
     try:
         placeholders = ",".join("?" for _ in artist_ids)
         cursor = await db.execute(
-            f"SELECT COUNT(*) as cnt FROM never_skip_artists WHERE id IN ({placeholders})",
+            f"SELECT COUNT(*) as cnt FROM never_skip_artists WHERE enabled = 1 AND id IN ({placeholders})",
             artist_ids,
         )
         row = await cursor.fetchone()

--- a/cloud/app/routers/artists.py
+++ b/cloud/app/routers/artists.py
@@ -47,10 +47,6 @@ class ArtistCreate(BaseModel):
     name: str
     image_url: str = ""
 
-
-class ArtistUpdate(BaseModel):
-    enabled: bool
-
     @field_validator("id")
     @classmethod
     def validate_id(cls, v: str) -> str:
@@ -63,6 +59,10 @@ class ArtistUpdate(BaseModel):
     @classmethod
     def validate_image_url(cls, v: str) -> str:
         return _validate_image_url(v.strip())
+
+
+class ArtistUpdate(BaseModel):
+    enabled: bool
 
 
 @router.get("")

--- a/cloud/app/routers/artists.py
+++ b/cloud/app/routers/artists.py
@@ -8,7 +8,12 @@ from urllib.parse import urlparse
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, field_validator
 
-from app.database import add_never_skip_artist, get_never_skip_artists, remove_never_skip_artist
+from app.database import (
+    add_never_skip_artist,
+    get_never_skip_artists,
+    remove_never_skip_artist,
+    set_never_skip_artist_enabled,
+)
 from app.routers.deps import require_auth
 from app.spotify_api import CredentialError
 from app.state import app_state
@@ -42,6 +47,10 @@ class ArtistCreate(BaseModel):
     name: str
     image_url: str = ""
 
+
+class ArtistUpdate(BaseModel):
+    enabled: bool
+
     @field_validator("id")
     @classmethod
     def validate_id(cls, v: str) -> str:
@@ -72,6 +81,17 @@ async def add_artist(body: ArtistCreate):
     if not artist_id or not name:
         raise HTTPException(status_code=400, detail="id and name are required")
     await add_never_skip_artist(artist_id, name, image_url)
+    return {"ok": True}
+
+
+@router.patch("/{artist_id}")
+async def update_artist(artist_id: str, body: ArtistUpdate):
+    """Toggle whether an artist's never-skip protection is active."""
+    if not _SPOTIFY_ID_RE.match(artist_id):
+        raise HTTPException(status_code=400, detail="Invalid artist ID")
+    updated = await set_never_skip_artist_enabled(artist_id, body.enabled)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Artist not found")
     return {"ok": True}
 
 

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -251,10 +251,13 @@ input:focus, select:focus {
     margin-bottom: 6px;
 }
 
-.form-group .help-text,
-.toggle-text .help-text {
+.help-text {
     font-size: 0.8rem;
     color: var(--text-muted);
+}
+
+.form-group .help-text,
+.toggle-text .help-text {
     margin-top: 4px;
 }
 
@@ -323,6 +326,11 @@ input:focus, select:focus {
 
 .toggle-switch input:checked + .toggle-slider { background: var(--accent); }
 .toggle-switch input:checked + .toggle-slider::before { transform: translateX(20px); }
+
+.toggle-switch input:disabled + .toggle-slider {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
 
 /* ── Artist List ─────────────────────────────────── */
 

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -369,6 +369,17 @@ input:focus, select:focus {
     text-overflow: ellipsis;
 }
 
+.artist-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+/* Dim the row when never-skip protection is toggled off, but keep the
+   toggle itself fully legible so it stays easy to switch back on. */
+.artist-disabled .artist-info { opacity: 0.4; }
+
 .artist-remove {
     background: none;
     border: none;

--- a/cloud/app/static/js/api.js
+++ b/cloud/app/static/js/api.js
@@ -44,6 +44,15 @@ const API = {
         return _handleResponse(r);
     },
 
+    async patch(url, body) {
+        const r = await fetch(url, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+        });
+        return _handleResponse(r);
+    },
+
     async del(url) {
         const r = await fetch(url, { method: "DELETE" });
         return _handleResponse(r);

--- a/cloud/app/static/js/app.js
+++ b/cloud/app/static/js/app.js
@@ -425,6 +425,7 @@ async function initArtists() {
         data.artists.forEach(a => {
             const div = document.createElement("div");
             div.className = "artist-item";
+            if (!a.enabled) div.classList.add("artist-disabled");
 
             const info = document.createElement("div");
             info.className = "artist-info";
@@ -446,6 +447,33 @@ async function initArtists() {
             nameSpan.textContent = a.name;
             info.appendChild(nameSpan);
 
+            const controls = document.createElement("div");
+            controls.className = "artist-controls";
+
+            const toggle = document.createElement("label");
+            toggle.className = "toggle-switch";
+            toggle.title = "Never-skip protection on/off";
+            const toggleInput = document.createElement("input");
+            toggleInput.type = "checkbox";
+            toggleInput.checked = !!a.enabled;
+            toggleInput.addEventListener("change", async () => {
+                const enabled = toggleInput.checked;
+                try {
+                    await API.patch(`/api/artists/${encodeURIComponent(a.id)}`, { enabled });
+                    div.classList.toggle("artist-disabled", !enabled);
+                    a.enabled = enabled;
+                    showToast(enabled ? `Protecting ${a.name}` : `Skipping ${a.name} again`);
+                } catch (err) {
+                    showToast(err.message || "Failed to update artist", 3000, "error");
+                    toggleInput.checked = !enabled;
+                }
+            });
+            const toggleSlider = document.createElement("span");
+            toggleSlider.className = "toggle-slider";
+            toggle.appendChild(toggleInput);
+            toggle.appendChild(toggleSlider);
+            controls.appendChild(toggle);
+
             const removeBtn = document.createElement("button");
             removeBtn.className = "artist-remove";
             removeBtn.title = "Remove";
@@ -454,9 +482,10 @@ async function initArtists() {
                 await API.del(`/api/artists/${encodeURIComponent(a.id)}`);
                 loadArtists();
             });
+            controls.appendChild(removeBtn);
 
             div.appendChild(info);
-            div.appendChild(removeBtn);
+            div.appendChild(controls);
             list.appendChild(div);
         });
     }

--- a/cloud/app/static/js/app.js
+++ b/cloud/app/static/js/app.js
@@ -400,6 +400,22 @@ async function initArtists() {
     const toggleNeverSkip = document.getElementById("toggle-never-skip");
     if (!list) return;
 
+    // Per-artist switches only matter while the whole feature is on, so
+    // disable them (and lock the list) whenever the master toggle is off.
+    function applyGlobalEnabledState() {
+        const enabled = toggleNeverSkip ? toggleNeverSkip.checked : true;
+        list.classList.toggle("artists-locked", !enabled);
+        list.querySelectorAll(".artist-toggle-input").forEach(inp => {
+            inp.disabled = !enabled;
+            const lbl = inp.closest(".toggle-switch");
+            if (lbl) {
+                lbl.title = enabled
+                    ? "Never-skip protection on/off"
+                    : "Enable never-skip artists above to use this";
+            }
+        });
+    }
+
     // Load and bind the enable toggle
     if (toggleNeverSkip) {
         const settings = await API.get("/api/settings");
@@ -407,10 +423,12 @@ async function initArtists() {
         toggleNeverSkip.addEventListener("change", async () => {
             try {
                 await API.put("/api/settings", { enable_never_skip_artists: toggleNeverSkip.checked });
+                applyGlobalEnabledState();
                 showToast(toggleNeverSkip.checked ? "Never-skip enabled" : "Never-skip disabled");
             } catch (err) {
                 showToast(err.message || "Failed to update setting", 3000, "error");
                 toggleNeverSkip.checked = !toggleNeverSkip.checked;
+                applyGlobalEnabledState();
             }
         });
     }
@@ -455,6 +473,7 @@ async function initArtists() {
             toggle.title = "Never-skip protection on/off";
             const toggleInput = document.createElement("input");
             toggleInput.type = "checkbox";
+            toggleInput.className = "artist-toggle-input";
             toggleInput.checked = !!a.enabled;
             toggleInput.addEventListener("change", async () => {
                 const enabled = toggleInput.checked;
@@ -488,6 +507,7 @@ async function initArtists() {
             div.appendChild(controls);
             list.appendChild(div);
         });
+        applyGlobalEnabledState();
     }
 
     let searchTimeout = null;

--- a/cloud/app/templates/artists.html
+++ b/cloud/app/templates/artists.html
@@ -6,7 +6,10 @@
 
     <div class="card">
         <div class="toggle">
-            <span class="toggle-label">Enable never-skip artists</span>
+            <div class="toggle-text">
+                <span class="toggle-label">Enable never-skip artists</span>
+                <div class="help-text">Tracks by the artists below are never skipped &mdash; even when they'd normally be skipped by your rules. Turn this off to pause protection for everyone at once.</div>
+            </div>
             <label class="toggle-switch">
                 <input type="checkbox" id="toggle-never-skip" data-setting="enable_never_skip_artists">
                 <span class="toggle-slider"></span>
@@ -22,6 +25,7 @@
 
     <div class="card">
         <div class="card-title">Your Artists</div>
+        <div class="help-text mt-8 mb-16">Each artist's switch turns their protection on or off without removing them from the list &mdash; handy for pausing one artist temporarily. These switches are disabled while the feature above is off.</div>
         <div id="artist-list"></div>
     </div>
 </div>


### PR DESCRIPTION
Closes #54.

## Sto
Svaki never-skip artist dobiva on/off switch. Kad je OFF, artist ostaje na listi ali ga se skipa po normalnim pravilima — vise se ne mora dodavati/micati da bi se privremeno (de)aktivirao.

## Promjene
- **DB** (`database.py`): nova `enabled` kolona (`INTEGER NOT NULL DEFAULT 1`) + migracija za postojece baze (svi postojeci artisti ostaju zasticeni). `is_artist_never_skipped` sada broji samo `enabled = 1`. Nova `set_never_skip_artist_enabled`.
- **API** (`routers/artists.py`): `PATCH /api/artists/{id}` s `{enabled: bool}`, 404 ako artist ne postoji.
- **Frontend**: per-artist toggle switch (reuse postojeceg `.toggle-switch`), red se dimm-a kad je protekcija off. Dodana `API.patch` metoda.

## Verifikacija
DB-sloj test (privremena baza): migracija stare baze bez `enabled` kolone, disable/re-enable, default za nove artiste, mixed lista, unknown id → sve assertion-e prolazi. Provjereno na tocki gdje se skip-odluka stvarno donosi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)