### PR TITLE
Fail-closed login when ALLOWED_SPOTIFY_USER is empty

### DIFF
--- a/cloud/.env.example
+++ b/cloud/.env.example
@@ -16,7 +16,12 @@ SECRET_KEY=
 # For production: https://skipper.yourdomain.com
 BASE_URL=https://your-server-url.com
 
-# (Optional) Restrict login to a single Spotify account.
-# Set to your Spotify user ID to block all other users.
-# Leave empty or omit to allow anyone to log in.
+# Restrict login to a single Spotify account (strongly recommended).
+# Set to your Spotify user ID so only you can log in.
+# If left empty, login is DISABLED by default (fail-closed) so a stranger who
+# finds the URL can't log in and overwrite your tokens with their own account.
 ALLOWED_SPOTIFY_USER=
+
+# Escape hatch: set to "true" to allow ANY Spotify account to log in while
+# ALLOWED_SPOTIFY_USER is empty. Insecure — only for throwaway/local testing.
+ALLOW_ANY_SPOTIFY_USER=

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.0-1"
+APP_VERSION = "v3.16.0"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.15.3"
+APP_VERSION = "v3.16.0-1"

--- a/cloud/app/config.py
+++ b/cloud/app/config.py
@@ -105,8 +105,15 @@ def get_base_url() -> str:
 
 
 def get_allowed_spotify_user() -> str:
-    """Spotify user ID whitelist. Empty string means no restriction."""
-    return os.environ.get("ALLOWED_SPOTIFY_USER", "")
+    """Spotify user ID whitelist. Empty string means no explicit whitelist
+    (login is then fail-closed unless get_allow_any_spotify_user() is set)."""
+    return os.environ.get("ALLOWED_SPOTIFY_USER", "").strip()
+
+
+def get_allow_any_spotify_user() -> bool:
+    """Explicit opt-out: allow ANY Spotify account to log in when
+    ALLOWED_SPOTIFY_USER is empty. Insecure — off by default."""
+    return os.environ.get("ALLOW_ANY_SPOTIFY_USER", "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 # ── Settings (from SQLite) ───────────────────────────────────────

--- a/cloud/app/main.py
+++ b/cloud/app/main.py
@@ -3,6 +3,7 @@ FastAPI application entry point.
 """
 
 import asyncio
+import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
@@ -13,10 +14,36 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from app import APP_VERSION
-from app.config import get_secret_key, get_spotify_client_id, get_spotify_client_secret, seed_defaults
+from app.config import (
+    get_allow_any_spotify_user,
+    get_allowed_spotify_user,
+    get_secret_key,
+    get_spotify_client_id,
+    get_spotify_client_secret,
+    seed_defaults,
+)
 from app.database import init_db
 from app.spotify_api import SpotifyClient
 from app.state import app_state
+
+_startup_log = logging.getLogger("startup")
+
+
+def _log_auth_posture() -> None:
+    """Warn loudly at startup about who is allowed to log in."""
+    if get_allowed_spotify_user():
+        _startup_log.info("Login restricted to Spotify user '%s'.", get_allowed_spotify_user())
+    elif get_allow_any_spotify_user():
+        _startup_log.warning(
+            "ALLOW_ANY_SPOTIFY_USER is enabled: ANY Spotify account can log in and take over "
+            "this instance. Set ALLOWED_SPOTIFY_USER to your Spotify user ID to lock it down."
+        )
+    else:
+        _startup_log.warning(
+            "ALLOWED_SPOTIFY_USER is not set — login is disabled (fail-closed). Set "
+            "ALLOWED_SPOTIFY_USER to your Spotify user ID, or set ALLOW_ANY_SPOTIFY_USER=true "
+            "to intentionally allow open login."
+        )
 
 
 @asynccontextmanager
@@ -24,6 +51,7 @@ async def lifespan(app: FastAPI):
     # Startup
     await init_db()
     await seed_defaults()
+    _log_auth_posture()
 
     # Create a single shared SpotifyClient for the entire process
     app_state.spotify_client = SpotifyClient(get_spotify_client_id(), get_spotify_client_secret())

--- a/cloud/app/routers/auth.py
+++ b/cloud/app/routers/auth.py
@@ -2,6 +2,7 @@
 Spotify OAuth Authorization Code Flow.
 """
 
+import logging
 import secrets
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
@@ -10,10 +11,18 @@ import httpx
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import RedirectResponse
 
-from app.config import get_allowed_spotify_user, get_base_url, get_spotify_client_id, get_spotify_client_secret
+from app.config import (
+    get_allow_any_spotify_user,
+    get_allowed_spotify_user,
+    get_base_url,
+    get_spotify_client_id,
+    get_spotify_client_secret,
+)
 from app.database import clear_oauth_tokens, save_oauth_tokens, set_reauth_required
 from app.routers.deps import require_auth
 from app.state import app_state
+
+log = logging.getLogger("auth")
 
 router = APIRouter(tags=["auth"])
 
@@ -98,14 +107,17 @@ async def callback(request: Request, code: str = "", state: str = "", error: str
                 if spotify_user_id != allowed_user:
                     return RedirectResponse("/unauthorized")
             else:
-                import logging
-
-                logging.getLogger("auth").warning(
-                    "Spotify /v1/me returned %s: %s", me_resp.status_code, me_resp.text[:200]
-                )
+                log.warning("Spotify /v1/me returned %s: %s", me_resp.status_code, me_resp.text[:200])
                 return RedirectResponse("/unauthorized")
         except httpx.RequestError:
             return RedirectResponse("/unauthorized")
+    elif not get_allow_any_spotify_user():
+        # No whitelist and no explicit opt-out: refuse rather than let a
+        # stranger take over this instance by overwriting the owner's tokens.
+        log.warning(
+            "Login rejected: ALLOWED_SPOTIFY_USER is not set and ALLOW_ANY_SPOTIFY_USER is not enabled."
+        )
+        return RedirectResponse("/unauthorized")
 
     await save_oauth_tokens(access_token, refresh_token, expires_at.isoformat())
     # Fresh token — clear any "re-authorization required" state so the dashboard

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -8,8 +8,8 @@ Svaka stavka je samostalna — sadrži file, problem i smjer popravka.
 - [x] **Jinja2 pin isključuje sigurnosni patch** — `cloud/requirements.txt:5` — DONE (v3.15.2, PR #63)
   `jinja2>=3.1.0,<3.1.6` pinira na 3.1.5, a upravo 3.1.6 fixa CVE-2025-27516 (sandbox escape kroz `|attr` filter). Cap izgleda kao tipfeler. Fix: promijeniti u `jinja2>=3.1.6,<3.2`. Nakon izmjene rebuildati i provjeriti da se templati normalno renderiraju. Deployano i verificirano zdravo (jinja2 3.1.6 u buildu).
 
-- [ ] **`ALLOWED_SPOTIFY_USER` prazan = svatko se može ulogirati** — `cloud/app/routers/auth.py` (callback), `cloud/.env.example:22`
-  Ako env var nije postavljen, bilo tko tko nađe URL prođe Spotify OAuth, postane "authenticated" i njegovi tokeni prebrišu vlasnikove. Fix: na startupu (lifespan u `main.py`) logirati jasan warning kad je `ALLOWED_SPOTIFY_USER` prazan; razmotriti i fail-closed (odbiti login) uz eksplicitni opt-out. Usput provjeriti da je var postavljen u `.env` na VPS-u (deploy skill ima pristup).
+- [x] **`ALLOWED_SPOTIFY_USER` prazan = svatko se može ulogirati** — DONE (v3.16.0)
+  Prazan `ALLOWED_SPOTIFY_USER` sada je fail-closed: login se odbija osim ako je eksplicitno postavljeno `ALLOW_ANY_SPOTIFY_USER=true`. Startup (lifespan u `main.py`) logira jasan warning o trenutnom auth stanju. `.env.example` dokumentira oba vara. PREOSTALO: postaviti `ALLOWED_SPOTIFY_USER` na Vatrin Spotify user ID u `.env` na VPS-u PRIJE deploya (inače fail-closed zaključa vlasnika pri sljedećem re-loginu).
 
 - [ ] **Worker može umrijeti od NameError** — `cloud/app/worker.py:350`
   Završni `await app_state.interruptible_sleep(poll_interval)` je unutar `while` petlje ali izvan `try/except`. Ako na prvoj iteraciji `load_settings()` (linija 124) baci iznimku prije dodjele `poll_interval` (linija 125), generic handler je uhvati, ali linija 350 onda digne NameError koji ubije task. Fix: inicijalizirati `poll_interval` prije petlje (npr. iz settings učitanih na liniji 104).


### PR DESCRIPTION
## Problem
An empty `ALLOWED_SPOTIFY_USER` meant **open login**: anyone who found the URL could complete Spotify OAuth, become "authenticated", and overwrite the owner's stored tokens with their own account. (TODO high-priority item.)

## Fix
Secure-by-default: an empty whitelist is now **fail-closed** — login is rejected unless the operator explicitly opts into open login.

- `cloud/app/routers/auth.py` — callback rejects login (→ `/unauthorized`) when `ALLOWED_SPOTIFY_USER` is empty **and** `ALLOW_ANY_SPOTIFY_USER` is not enabled.
- `cloud/app/config.py` — new `get_allow_any_spotify_user()`; `get_allowed_spotify_user()` now trims whitespace.
- `cloud/app/main.py` — lifespan logs a clear startup warning describing the active auth posture (restricted / open / disabled).
- `cloud/.env.example` — documents both variables and the new default.

## Behaviour
| `ALLOWED_SPOTIFY_USER` | `ALLOW_ANY_SPOTIFY_USER` | Result |
|---|---|---|
| set | — | only that user (unchanged) |
| empty | not `true` | **login rejected (fail-closed)** |
| empty | `true` | open login (explicit opt-out) |

## ⚠️ Deploy prerequisite
Before releasing/deploying to production, set `ALLOWED_SPOTIFY_USER` to the owner's Spotify user ID in the VPS `.env` (or `ALLOW_ANY_SPOTIFY_USER=true`). Otherwise fail-closed will lock the owner out on the next re-login.

## Verification
- `py_compile` clean; full `app.main` import clean (no import-time errors).
- `get_allowed_spotify_user()` / `get_allow_any_spotify_user()` parsing tested across empty, whitespace, `true/TRUE/1/yes`, `false/0`.

Test snapshot version `v3.16.0-1` — not yet released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)