### PR TITLE
Fix worker NameError killing the task when load_settings() fails on first iteration

### DIFF
--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.1-1"
+APP_VERSION = "v3.16.1"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.0"
+APP_VERSION = "v3.16.1-1"

--- a/cloud/app/worker.py
+++ b/cloud/app/worker.py
@@ -118,6 +118,13 @@ async def polling_loop():
     app_state.last_checked_track_id = await get_last_track_event_id()
     last_purge = datetime.now(timezone.utc)
 
+    # Seed poll_interval before the loop so the trailing sleep (and the generic
+    # exception handler's sleep) always has a value. Otherwise a load_settings()
+    # failure on the very first iteration would leave poll_interval unassigned,
+    # and the sleep on the last line of the loop would raise NameError — killing
+    # the worker instead of retrying.
+    poll_interval = settings["poll_interval_seconds"]
+
     while True:
         try:
             # Reload settings each cycle so changes take effect

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -11,8 +11,8 @@ Svaka stavka je samostalna — sadrži file, problem i smjer popravka.
 - [x] **`ALLOWED_SPOTIFY_USER` prazan = svatko se može ulogirati** — DONE (v3.16.0)
   Prazan `ALLOWED_SPOTIFY_USER` sada je fail-closed: login se odbija osim ako je eksplicitno postavljeno `ALLOW_ANY_SPOTIFY_USER=true`. Startup (lifespan u `main.py`) logira jasan warning o trenutnom auth stanju. `.env.example` dokumentira oba vara. PREOSTALO: postaviti `ALLOWED_SPOTIFY_USER` na Vatrin Spotify user ID u `.env` na VPS-u PRIJE deploya (inače fail-closed zaključa vlasnika pri sljedećem re-loginu).
 
-- [ ] **Worker može umrijeti od NameError** — `cloud/app/worker.py:350`
-  Završni `await app_state.interruptible_sleep(poll_interval)` je unutar `while` petlje ali izvan `try/except`. Ako na prvoj iteraciji `load_settings()` (linija 124) baci iznimku prije dodjele `poll_interval` (linija 125), generic handler je uhvati, ali linija 350 onda digne NameError koji ubije task. Fix: inicijalizirati `poll_interval` prije petlje (npr. iz settings učitanih na liniji 104).
+- [x] **Worker može umrijeti od NameError** — `cloud/app/worker.py` — DONE (v3.16.1)
+  Završni `await app_state.interruptible_sleep(poll_interval)` je unutar `while` petlje ali izvan `try/except`. Ako na prvoj iteraciji `load_settings()` baci iznimku prije dodjele `poll_interval`, generic handler je uhvati, ali sleep na kraju petlje onda digne NameError koji ubije task. Fix: `poll_interval` inicijaliziran prije petlje iz settingsa učitanih pri startupu.
 
 - [ ] **Rediscovery ignorira track_id aliase** — `cloud/app/rediscovery.py:84`
   Poziva `get_last_play_date(artist, name)` bez `track_id`, iako ga ima (`track["id"]` iz playlist items). Aliasi keyani po track_id (moderni, iz Loved Sync / mapping-fails) se ne primjenjuju, pa pjesme s poznatim Spotify↔Last.fm mapping problemima ispadnu "nikad slušane" i pogrešno uđu u Rediscovery playlistu. Fix: proslijediti `track["id"]` kao treći argument.


### PR DESCRIPTION
## Problem

`polling_loop()` in `cloud/app/worker.py` had a `NameError` crash path that could kill the background worker.

The trailing `await app_state.interruptible_sleep(poll_interval)` at the end of the `while True:` loop sits **inside** the loop but **outside** the `try/except`. `poll_interval` is only assigned inside the `try` (from `load_settings()`). On the very first iteration, if `load_settings()` raised before `poll_interval` was assigned:

1. The generic `except Exception` handler caught the exception and logged "Unexpected error"
2. Execution fell through to the trailing sleep, which referenced an unassigned `poll_interval`
3. `NameError` was raised outside any handler → propagated out of `polling_loop()` → worker task died → `/health` returns 503

Ironically the generic handler exists precisely to keep the worker alive through transient errors, but this path defeated it on the first cycle.

## Fix

Seed `poll_interval` from the startup settings load (already fetched before the loop) so it is always defined before the loop body runs. Minimal, matches the TODO's suggested direction.

## Testing

Static fix, verified by reading — no local Docker in PATH, render/health verification happens on the VPS at deploy time. Health check will confirm `v3.16.1` in the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)