### PR TITLE
Fix rediscovery ignoring track_id aliases

### DIFF
--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.2-1"
+APP_VERSION = "v3.16.2"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.1"
+APP_VERSION = "v3.16.2-1"

--- a/cloud/app/rediscovery.py
+++ b/cloud/app/rediscovery.py
@@ -77,11 +77,12 @@ async def run_rediscovery_job(app_state, playlist_id: str, playlist_name: str):
             artist = track["artist"]
             name = track["name"]
             uri = track["uri"]
+            track_id = track["id"]
 
             # Query Last.fm with retries
             result = None
             for attempt in range(LASTFM_MAX_RETRIES + 1):
-                result = await get_last_play_date(artist, name)
+                result = await get_last_play_date(artist, name, track_id)
                 if result is not LASTFM_ERROR:
                     break
                 if attempt < LASTFM_MAX_RETRIES:

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -14,8 +14,8 @@ Svaka stavka je samostalna — sadrži file, problem i smjer popravka.
 - [x] **Worker može umrijeti od NameError** — `cloud/app/worker.py` — DONE (v3.16.1)
   Završni `await app_state.interruptible_sleep(poll_interval)` je unutar `while` petlje ali izvan `try/except`. Ako na prvoj iteraciji `load_settings()` baci iznimku prije dodjele `poll_interval`, generic handler je uhvati, ali sleep na kraju petlje onda digne NameError koji ubije task. Fix: `poll_interval` inicijaliziran prije petlje iz settingsa učitanih pri startupu.
 
-- [ ] **Rediscovery ignorira track_id aliase** — `cloud/app/rediscovery.py:84`
-  Poziva `get_last_play_date(artist, name)` bez `track_id`, iako ga ima (`track["id"]` iz playlist items). Aliasi keyani po track_id (moderni, iz Loved Sync / mapping-fails) se ne primjenjuju, pa pjesme s poznatim Spotify↔Last.fm mapping problemima ispadnu "nikad slušane" i pogrešno uđu u Rediscovery playlistu. Fix: proslijediti `track["id"]` kao treći argument.
+- [x] **Rediscovery ignorira track_id aliase** — `cloud/app/rediscovery.py:84` — DONE (v3.16.2, PR #66)
+  Pozivao `get_last_play_date(artist, name)` bez `track_id`, iako ga ima (`track["id"]` iz playlist items). Aliasi keyani po track_id (moderni, iz Loved Sync / mapping-fails) se nisu primjenjivali, pa su pjesme s poznatim Spotify↔Last.fm mapping problemima ispadale "nikad slušane" i pogrešno ulazile u Rediscovery playlistu. Fix: `track["id"]` proslijeđen kao treći argument (kao u `worker.py:195`).
 
 - [ ] **Tihi parcijalni fetch kod Spotify paginacije** — `cloud/app/rediscovery.py:40-52`, `cloud/app/spotify_api.py` (`get_all_saved_tracks`, `get_user_playlists`)
   Kad neka stranica paginacije vrati grešku, `get_playlist_tracks` vrati `{items: [], total: 0}` pa petlja pukne i job nastavi s dijelom pjesama kao da je sve dohvaćeno; `get_all_saved_tracks`/`get_user_playlists` na grešku samo `break`-aju (Loved Sync diff onda računa s nepotpunom Liked listom). Fix: razlikovati "kraj liste" od "greška" (npr. vratiti None / raise na ne-200) i job failati ili retryati umjesto tihog nastavka.


### PR DESCRIPTION
## Problem

`run_rediscovery_job` (`cloud/app/rediscovery.py:84`) called `get_last_play_date(artist, name)` without the `track_id`, even though it's available (`track["id"]` from playlist items).

Aliases in `track_aliases` are keyed primarily by Spotify `track_id` (created via Loved Sync / mapping-fails). Without passing the id, those id-keyed aliases were never applied — so tracks with known Spotify↔Last.fm mapping problems looked "never scrobbled" and wrongly entered the Rediscovery playlist.

## Fix

Pass `track["id"]` as the third argument to `get_last_play_date`, matching how `worker.py:195` already calls it.

## Testing

- `py_compile` passes.
- Render/health verification happens on VPS at deploy (Docker not local).

Test snapshot version: `v3.16.2-1`.

From `docs/todo.md` — high-priority item "Rediscovery ignorira track_id aliase".

🤖 Generated with [Claude Code](https://claude.com/claude-code)