### PR TITLE
Fix silent partial fetch on Spotify pagination

### DIFF
--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.3-1"
+APP_VERSION = "v3.16.3"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.2"
+APP_VERSION = "v3.16.3-1"

--- a/cloud/app/loved_sync.py
+++ b/cloud/app/loved_sync.py
@@ -12,7 +12,7 @@ from difflib import SequenceMatcher
 
 from app.database import get_all_track_aliases, get_loved_sync_ignored
 from app.lastfm_api import LASTFM_ERROR, get_loved_tracks
-from app.spotify_api import CredentialError
+from app.spotify_api import CredentialError, SpotifyAPIError
 
 
 def _norm_key(artist: str, name: str) -> tuple[str, str]:
@@ -107,6 +107,10 @@ async def compute_diff(spotify_client, lastfm_username: str) -> dict:
         spotify_liked = await spotify_client.get_all_saved_tracks()
     except CredentialError as e:
         return {"ok": False, "error": f"Spotify auth: {e}"}
+    except SpotifyAPIError as e:
+        # A failed page would leave the Liked list incomplete; bail rather than
+        # diff against partial data and mislabel tracks as "loved not liked".
+        return {"ok": False, "error": f"Spotify: {e}"}
 
     loved = await get_loved_tracks(lastfm_username)
     if loved == LASTFM_ERROR:

--- a/cloud/app/routers/rediscovery.py
+++ b/cloud/app/routers/rediscovery.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 from app.rediscovery import run_rediscovery_job
 from app.routers.deps import require_auth
-from app.spotify_api import CredentialError
+from app.spotify_api import CredentialError, SpotifyAPIError
 from app.state import app_state
 
 router = APIRouter(prefix="/api/rediscovery", tags=["rediscovery"], dependencies=[Depends(require_auth)])
@@ -30,6 +30,8 @@ async def list_playlists():
         playlists = await client.get_user_playlists()
     except CredentialError:
         raise HTTPException(status_code=401, detail="Spotify credentials expired.")
+    except SpotifyAPIError as e:
+        raise HTTPException(status_code=502, detail=f"Could not load playlists from Spotify: {e}")
     return {"playlists": playlists}
 
 

--- a/cloud/app/spotify_api.py
+++ b/cloud/app/spotify_api.py
@@ -30,6 +30,27 @@ class ReauthRequiredError(CredentialError):
     pass
 
 
+class SpotifyAPIError(Exception):
+    """Raised when a Spotify API request fails after retries.
+
+    Distinct from CredentialError: this covers non-auth failures (network
+    exhausted, 5xx, unexpected non-200). It exists so paginating helpers can
+    fail loudly instead of silently returning partial data mid-pagination —
+    partial results would corrupt downstream logic (an incomplete Liked list
+    poisons the Loved Sync diff; a truncated playlist scan makes Rediscovery
+    treat unfetched tracks as if they don't exist).
+    """
+
+    pass
+
+
+def _spotify_error(r: httpx.Response | None, context: str) -> SpotifyAPIError:
+    """Build a descriptive SpotifyAPIError from a failed response (or None)."""
+    if r is None:
+        return SpotifyAPIError(f"{context}: network error (retries exhausted)")
+    return SpotifyAPIError(f"{context}: HTTP {r.status_code}")
+
+
 class SpotifyClient:
     """Async Spotify API client with token management and rate-limit retry."""
 
@@ -281,7 +302,7 @@ class SpotifyClient:
                 params={"limit": 50, "offset": offset},
             )
             if r is None or r.status_code != 200:
-                break
+                raise _spotify_error(r, f"Fetching Liked Songs at offset {offset}")
             data = r.json() or {}
             for entry in data.get("items") or []:
                 track = entry.get("track") or {}
@@ -363,7 +384,7 @@ class SpotifyClient:
                 params={"limit": 50, "offset": offset},
             )
             if r is None or r.status_code != 200:
-                break
+                raise _spotify_error(r, f"Fetching playlists at offset {offset}")
             data = r.json()
             for p in data.get("items") or []:
                 if not p or not p.get("id"):
@@ -383,7 +404,12 @@ class SpotifyClient:
         return results
 
     async def get_playlist_tracks(self, playlist_id: str, limit: int = 100, offset: int = 0) -> dict:
-        """Return a page of playlist tracks. Returns {items: [...], total: int}."""
+        """Return a page of playlist tracks. Returns {items: [...], total: int}.
+
+        Raises SpotifyAPIError on a failed page so callers can't mistake a
+        fetch error for the end of the list (which would silently truncate a
+        Rediscovery scan).
+        """
         r = await self._get(
             f"https://api.spotify.com/v1/playlists/{playlist_id}/tracks",
             params={
@@ -393,7 +419,7 @@ class SpotifyClient:
             },
         )
         if r is None or r.status_code != 200:
-            return {"items": [], "total": 0}
+            raise _spotify_error(r, f"Fetching playlist tracks at offset {offset}")
         data = r.json()
         items = []
         for entry in data.get("items") or []:

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -17,8 +17,8 @@ Svaka stavka je samostalna — sadrži file, problem i smjer popravka.
 - [x] **Rediscovery ignorira track_id aliase** — `cloud/app/rediscovery.py:84` — DONE (v3.16.2, PR #66)
   Pozivao `get_last_play_date(artist, name)` bez `track_id`, iako ga ima (`track["id"]` iz playlist items). Aliasi keyani po track_id (moderni, iz Loved Sync / mapping-fails) se nisu primjenjivali, pa su pjesme s poznatim Spotify↔Last.fm mapping problemima ispadale "nikad slušane" i pogrešno ulazile u Rediscovery playlistu. Fix: `track["id"]` proslijeđen kao treći argument (kao u `worker.py:195`).
 
-- [ ] **Tihi parcijalni fetch kod Spotify paginacije** — `cloud/app/rediscovery.py:40-52`, `cloud/app/spotify_api.py` (`get_all_saved_tracks`, `get_user_playlists`)
-  Kad neka stranica paginacije vrati grešku, `get_playlist_tracks` vrati `{items: [], total: 0}` pa petlja pukne i job nastavi s dijelom pjesama kao da je sve dohvaćeno; `get_all_saved_tracks`/`get_user_playlists` na grešku samo `break`-aju (Loved Sync diff onda računa s nepotpunom Liked listom). Fix: razlikovati "kraj liste" od "greška" (npr. vratiti None / raise na ne-200) i job failati ili retryati umjesto tihog nastavka.
+- [x] **Tihi parcijalni fetch kod Spotify paginacije** — DONE (v3.16.3, PR #67)
+  Nova iznimka `SpotifyAPIError` baca se na ne-200 / mrežni fail nakon iscrpljenih retryja (tranzijentni network/429/401 već retrya `_request`), pa se greška u paginaciji više ne može tiho progutati. `get_playlist_tracks`/`get_all_saved_tracks`/`get_user_playlists` sada raise-aju umjesto da vraćaju parcijalne podatke. Calleri razlikuju "kraj liste" od "greške": Rediscovery job faila čisto (već ima try/except oko Phase 1), `compute_diff` (Loved Sync) vrati `{ok: False}` → 502, `list_playlists` vrati 502 umjesto parcijalnog dropdowna.
 
 ## Srednji prioritet
 


### PR DESCRIPTION
## Problem
Paginating helpers silently returned partial data when a page failed, instead of signalling the error:

- **`get_playlist_tracks`** returned `{items: [], total: 0}` on a failed page. The Rediscovery Phase 1 loop then saw `total == 0`, hit `offset >= total`, and **stopped early** — treating a partial scan as the whole playlist. Tracks on unfetched pages were effectively invisible to the scan.
- **`get_all_saved_tracks` / `get_user_playlists`** just `break`-ed out of the pagination loop on error, returning a truncated list. Loved Sync then diffed against an **incomplete Liked list** (mislabeling tracks as "loved, not liked").

## Fix
New `SpotifyAPIError`, raised on non-200 / network-exhausted pages. Transient network / 429 / 401 are already retried inside `_request`, so reaching the raise means retries are exhausted — a real error, not the end of the list.

Callers now distinguish "end of list" from "error":
- **Rediscovery** Phase 1 already wraps the loop in `try/except` → job fails cleanly instead of building a truncated playlist.
- **`compute_diff`** (Loved Sync) catches it → returns `{ok: False}` → router responds 502.
- **`list_playlists`** returns 502 instead of a partial dropdown.

## Test version
`v3.16.3-1` (test snapshot; final version set at release).

Resolves the "Tihi parcijalni fetch kod Spotify paginacije" TODO item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
