### PR TITLE
Fix escapeHtml not escaping quotes in HTML attributes

### DIFF
--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.3"
+APP_VERSION = "v3.16.4-1"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.4-1"
+APP_VERSION = "v3.16.4"

--- a/cloud/app/static/js/app.js
+++ b/cloud/app/static/js/app.js
@@ -1360,9 +1360,10 @@ function initArtistChart() {
 // ── Utilities ───────────────────────────────────────────────────
 
 function escapeHtml(text) {
-    const div = document.createElement("div");
-    div.textContent = text;
-    return div.innerHTML;
+    if (text == null) return "";
+    return String(text).replace(/[&<>"']/g, c => ({
+        "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+    }[c]));
 }
 
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -22,8 +22,8 @@ Svaka stavka je samostalna — sadrži file, problem i smjer popravka.
 
 ## Srednji prioritet
 
-- [ ] **`escapeHtml` ne escapa navodnike, a koristi se u HTML atributima** — `cloud/app/static/js/app.js:1362` (definicija), korišteno u `value="..."` (~linija 809, 971) i `href="..."` (~864)
-  Trik s `textContent`/`innerHTML` ne escapa `"`, pa naziv pjesme s navodnikom razbija atribut (attribute injection; CSP blokira inline handlere pa nije praktični XSS, ali lomi UI). Fix: escapeHtml zamijeniti replace-mapom koja pokriva i `"` i `'`.
+- [x] **`escapeHtml` ne escapa navodnike, a koristi se u HTML atributima** — `cloud/app/static/js/app.js:1362` — DONE (v3.16.4, PR #68)
+  Trik s `textContent`/`innerHTML` nije escapao `"`/`'`, pa je naziv s navodnikom razbijao atribut (`value="..."`, `href="..."`). Fix: `escapeHtml` zamijenjen regex replace-mapom (`& < > " '`), identično onoj u `loved_sync.js`, uz null-guard za staro ponašanje.
 
 - [ ] **`is_track_liked` na svakom dashboard pollu** — `cloud/app/routers/playback.py` (`get_playback`), frontend polla svakih 5 s (`app.js` `setInterval(updatePlayback, 5000)`)
   Svaki poll radi pravi Spotify API poziv za liked status — 720 req/h po otvorenom tabu, za istu pjesmu iznova; nepotrebna izloženost 429. Fix: keširati liked status po track id-u u `app_state` i invalidirati kad se pjesma promijeni ili na toggle-like.


### PR DESCRIPTION
## Problem

`escapeHtml` u `cloud/app/static/js/app.js` koristio je `textContent`/`innerHTML` trik koji **ne escapa `"` ni `'`**. Rezultat se interpolira u HTML atribute:

- `value="${escapeHtml(...)}"` — mapping-fail alias inputi (`app.js:809`, `971`)
- `href="${escapeHtml(link)}"` — Last.fm scrobble link (`app.js:864`)

Naziv pjesme/aliasa s navodnikom (npr. `Best of" onmouseover="...`) izlazio je iz atributa (attribute injection). CSP blokira inline handlere pa nije praktični XSS, ali lomi UI.

## Fix

`escapeHtml` zamijenjen regex replace-mapom koja pokriva `& < > " '`, identično postojećoj `escapeHtml` u `loved_sync.js` (konzistentnost). Null/undefined guard čuva staro ponašanje (prazan string).

Verificirano node testom: `"` → `&quot;`, `'` → `&#39;`, `& < >` i dalje escapani, `null`/`undefined` → `""`, brojevi coerce-ani.

Verzija bumpana na test snapshot `v3.16.4-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)