### PR TITLE
Cache liked status to avoid a Spotify call on every dashboard poll

### DIFF
--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.5-1"
+APP_VERSION = "v3.16.5"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.4"
+APP_VERSION = "v3.16.5-1"

--- a/cloud/app/routers/playback.py
+++ b/cloud/app/routers/playback.py
@@ -21,6 +21,30 @@ _AUTO_ALIAS_NAME_SIM = 0.8  # track name similarity floor
 router = APIRouter(prefix="/api/playback", tags=["playback"], dependencies=[Depends(require_auth)])
 
 
+async def _get_liked_cached(track_id: str) -> bool | None:
+    """Liked status for track_id, cached across dashboard polls.
+
+    The cache (app_state.liked_status_cache) holds only the current track, so a
+    different track_id is a miss and triggers exactly one Spotify call. Returns
+    None if the Spotify client is unavailable or the lookup fails — matching the
+    prior get_playback behavior. On a Spotify-side like/unlike from another client
+    the cached value stays until the song changes; toggle_like refreshes it here.
+    """
+    cache = app_state.liked_status_cache
+    if track_id in cache:
+        return cache[track_id]
+    client = app_state.spotify_client
+    if not client:
+        return None
+    try:
+        is_liked = await client.is_track_liked(track_id)
+    except Exception:
+        return None
+    # Single-entry cache: replace so previous track ids don't accumulate.
+    app_state.liked_status_cache = {track_id: is_liked}
+    return is_liked
+
+
 @router.get("")
 async def get_playback(request: Request):
     """Return current track info and worker status."""
@@ -29,12 +53,7 @@ async def get_playback(request: Request):
 
     is_liked: bool | None = None
     if track and track.get("id"):
-        client = app_state.spotify_client
-        if client:
-            try:
-                is_liked = await client.is_track_liked(track["id"])
-            except Exception:
-                is_liked = None
+        is_liked = await _get_liked_cached(track["id"])
 
     return {
         "track": track,
@@ -238,6 +257,10 @@ async def toggle_like(request: Request):
             )
         new_state = True
         action_word = "Liked"
+
+    # Refresh the dashboard cache so the next poll reflects the toggle immediately
+    # (otherwise the button would flip back to the stale cached state).
+    app_state.liked_status_cache = {track_id: new_state}
 
     lastfm_synced: bool | None = None
     lastfm_error: str | None = None

--- a/cloud/app/state.py
+++ b/cloud/app/state.py
@@ -22,6 +22,11 @@ class AppState:
         self.spotify_client = None  # Shared SpotifyClient, set during lifespan
         self.worker_task: asyncio.Task | None = None  # Reference to polling_loop task
 
+        # Liked-status cache for the dashboard poll. Single-entry (holds only the
+        # most recently queried track_id) so it never accumulates stale ids. Avoids
+        # a Spotify /me/tracks/contains call on every 5s poll; a new track is a miss.
+        self.liked_status_cache: dict[str, bool] = {}
+
         # Rediscovery
         self.rediscovery_task: asyncio.Task | None = None
         self.rediscovery_status: str = "idle"  # idle/running/completed/failed

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -25,8 +25,8 @@ Svaka stavka je samostalna — sadrži file, problem i smjer popravka.
 - [x] **`escapeHtml` ne escapa navodnike, a koristi se u HTML atributima** — `cloud/app/static/js/app.js:1362` — DONE (v3.16.4, PR #68)
   Trik s `textContent`/`innerHTML` nije escapao `"`/`'`, pa je naziv s navodnikom razbijao atribut (`value="..."`, `href="..."`). Fix: `escapeHtml` zamijenjen regex replace-mapom (`& < > " '`), identično onoj u `loved_sync.js`, uz null-guard za staro ponašanje.
 
-- [ ] **`is_track_liked` na svakom dashboard pollu** — `cloud/app/routers/playback.py` (`get_playback`), frontend polla svakih 5 s (`app.js` `setInterval(updatePlayback, 5000)`)
-  Svaki poll radi pravi Spotify API poziv za liked status — 720 req/h po otvorenom tabu, za istu pjesmu iznova; nepotrebna izloženost 429. Fix: keširati liked status po track id-u u `app_state` i invalidirati kad se pjesma promijeni ili na toggle-like.
+- [x] **`is_track_liked` na svakom dashboard pollu** — `cloud/app/routers/playback.py` (`get_playback`) — DONE (v3.16.5, PR #69)
+  Poll je radio pravi Spotify `/me/tracks/contains` poziv svakih 5 s (720 req/h po otvorenom tabu). Fix: liked status keširan po track_id-u u `app_state.liked_status_cache` (single-entry — drži samo trenutnu pjesmu, ne akumulira stale id-eve). Poll gađa Spotify samo na miss (nova pjesma); `toggle_like` upisuje novo stanje u cache pa se toggle odmah reflektira umjesto da se dugme vrati na staru vrijednost. Worker netaknut (već zove `is_track_liked` najviše jednom po pjesmi). Tradeoff: like/unlike s drugog Spotify klijenta ne vidi se na dashboardu dok se pjesma ne promijeni.
 
 - [ ] **Unhealthy container se ne restarta sam** — `cloud/Dockerfile` (HEALTHCHECK), `cloud/docker-compose.yml`
   `restart: unless-stopped` reagira samo na exit procesa, ne na unhealthy status — kad worker umre, container ostane unhealthy ali živ. Odlučiti: ili autoheal (npr. willfarrell/autoheal companion), ili da app sama exita kad je worker mrtav dulje od N minuta, ili svjesno ostaviti kao signal-only (onda zapisati tu odluku u CLAUDE.md).


### PR DESCRIPTION
## Problem

The dashboard polls `GET /api/playback` every 5s. `get_playback` ran a real Spotify `GET /me/tracks/contains` request on **every** poll — ~720 requests/hour per open tab, all for the same track's liked status. Needless load and 429 exposure.

## Fix

Cache the liked status per `track_id` in `app_state.liked_status_cache` (single-entry — it holds only the most recently queried track, so it never accumulates stale ids and needs no cleanup):

- `get_playback` → new `_get_liked_cached()` helper: returns the cached value on a hit, otherwise makes exactly one Spotify call (on a cache miss, i.e. a new song) and stores it. Returns `None` on missing client / lookup failure, same as before.
- `toggle_like` writes the new state into the cache so the next poll reflects the toggle immediately, instead of flipping the button back to the stale cached value.
- Worker is untouched — it already calls `is_track_liked` at most once per new song, not per poll.

Result: Spotify is hit ~once per song instead of every 5s.

## Tradeoff

A like/unlike performed from **another** Spotify client (phone, desktop app) won't appear on the dashboard until the song changes (previously reflected within 5s). Acceptable for a single-user app — the in-app Like button stays authoritative and refreshes the cache on use.

## Version

`v3.16.5-1` (test snapshot). PATCH — efficiency fix, no behavior change to the API contract (`is_liked` field unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)