### PR TITLE
restart_playlist: check every PUT, log + return False on failure

### DIFF
--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.6"
+APP_VERSION = "v3.16.7-1"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.7-1"
+APP_VERSION = "v3.16.7"

--- a/cloud/app/spotify_api.py
+++ b/cloud/app/spotify_api.py
@@ -5,11 +5,14 @@ Uses httpx.AsyncClient, class-based token management.
 
 import asyncio
 import base64
+import logging
 from datetime import datetime, timedelta, timezone
 
 import httpx
 
 from app.database import clear_oauth_tokens, get_oauth_tokens, save_oauth_tokens, set_reauth_required
+
+logger = logging.getLogger(__name__)
 
 
 class CredentialError(Exception):
@@ -267,8 +270,18 @@ class SpotifyClient:
     async def pause_spotify_playback(self):
         await self._put("https://api.spotify.com/v1/me/player/pause")
 
-    async def restart_playlist(self, dummy_playlist_id: str):
-        """Restart the current playlist (shuffle on) to break repeating patterns."""
+    async def restart_playlist(self, dummy_playlist_id: str) -> bool:
+        """Restart the current playlist (shuffle on) to break repeating patterns.
+
+        Bounces playback onto a dummy playlist, re-enables shuffle, then jumps
+        back to the original context. Returns True only if every PUT succeeded;
+        on any failure it logs a warning and returns False so the caller knows
+        the restart silently degraded. The first PUT is the usual culprit — an
+        invalid ``dummy_playlist_id`` (the default is a Spotify editorial
+        playlist, which the API restricts for newer apps) makes it 404, and
+        without this check the "restart" would look successful while doing
+        nothing.
+        """
         r = await self._get("https://api.spotify.com/v1/me/player/currently-playing")
         if r is None or r.status_code != 200:
             return False
@@ -278,16 +291,39 @@ class SpotifyClient:
         if not context_uri:
             return False
 
-        await self._put(
+        def _detail(resp: httpx.Response | None) -> str:
+            return "network error" if resp is None else f"HTTP {resp.status_code}"
+
+        # Jump to the dummy playlist. If this fails, playback is untouched and
+        # the rest of the dance is pointless — abort before disturbing anything.
+        r = await self._put(
             "https://api.spotify.com/v1/me/player/play", json={"context_uri": f"spotify:playlist:{dummy_playlist_id}"}
         )
+        if r is None or r.status_code not in (200, 202, 204):
+            logger.warning(
+                "[Spotify] restart_playlist: jump to dummy playlist %s failed (%s) — aborting restart",
+                dummy_playlist_id,
+                _detail(r),
+            )
+            return False
         await asyncio.sleep(1)
 
-        await self._put("https://api.spotify.com/v1/me/player/shuffle", params={"state": "true"})
+        # Playback is now on the dummy playlist, so we always attempt the jump
+        # back even if shuffle fails — otherwise the user is stranded there.
+        success = True
+
+        r = await self._put("https://api.spotify.com/v1/me/player/shuffle", params={"state": "true"})
+        if r is None or r.status_code not in (200, 202, 204):
+            logger.warning("[Spotify] restart_playlist: enabling shuffle failed (%s)", _detail(r))
+            success = False
         await asyncio.sleep(1)
 
-        await self._put("https://api.spotify.com/v1/me/player/play", json={"context_uri": context_uri})
-        return True
+        r = await self._put("https://api.spotify.com/v1/me/player/play", json={"context_uri": context_uri})
+        if r is None or r.status_code not in (200, 202, 204):
+            logger.warning("[Spotify] restart_playlist: jump back to original context failed (%s)", _detail(r))
+            success = False
+
+        return success
 
     async def get_all_saved_tracks(self) -> list[dict]:
         """Return all of the user's Liked Songs (paginates automatically).

--- a/cloud/app/worker.py
+++ b/cloud/app/worker.py
@@ -307,7 +307,11 @@ async def polling_loop():
                                     f"Detected repeating pattern ({threshold} skips) \u2014 restarting playlist...",
                                     "warning",
                                 )
-                                await client.restart_playlist(settings["dummy_playlist_id"])
+                                if not await client.restart_playlist(settings["dummy_playlist_id"]):
+                                    await _log(
+                                        "Playlist restart failed — check the dummy playlist ID in settings.",
+                                        "warning",
+                                    )
                                 recent_skip_days.clear()
 
                         await asyncio.sleep(1)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -31,8 +31,8 @@ Svaka stavka je samostalna — sadrži file, problem i smjer popravka.
 - [x] **Unhealthy container se ne restarta sam** — `cloud/app/worker.py`, `cloud/app/main.py` — DONE (v3.16.6)
   Rješenje: in-process supervizor (`worker_supervisor`, spawnan u lifespanu) koji restarta worker task **samo na crash** (`task.exception() is not None`), preko postojećeg `restart_worker_if_dead()`, uz eksponencijalni backoff. Uredan reauth/credential return ostaje netaknut (čeka korisnika na `/auth/login`). Svjesno BEZ container autoheala/self-exita: naivni autoheal bi restart-loopao na reauth-503; zaglavljeni-proces rep ostaje signal-only preko Docker HEALTHCHECK-a (odluka zapisana u CLAUDE.md, Health Monitoring).
 
-- [ ] **`restart_playlist` ne provjerava uspjeh PUT-ova** — `cloud/app/spotify_api.py` (`restart_playlist`)
-  Prvi PUT (skok na dummy playlistu) se ne provjerava; ako je `dummy_playlist_id` nevažeći (default je Spotifyjev editorial playlist, koje API od 2024. ograničava novim appovima), "restart" tiho degradira. Fix: provjeriti status svakog PUT-a, na grešku vratiti False i logirati.
+- [x] **`restart_playlist` ne provjerava uspjeh PUT-ova** — `cloud/app/spotify_api.py` (`restart_playlist`) — DONE (v3.16.7)
+  Svaki PUT (skok na dummy, shuffle on, skok natrag) sada provjerava status; na grešku logira warning i vraća False. Prvi PUT (skok na dummy playlistu) aborta rano ako padne — playback netaknut. Ako je skok na dummy uspio, skok natrag na originalni kontekst se **uvijek** pokuša (i kad shuffle padne) da korisnik ne ostane zaglavljen na dummy playlisti. Worker call-site (`worker.py`) sada površi neuspjeh u user-facing log ("Playlist restart failed — check the dummy playlist ID in settings.").
 
 ## Nizak prioritet / čišćenje
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -31,7 +31,7 @@ Svaka stavka je samostalna — sadrži file, problem i smjer popravka.
 - [x] **Unhealthy container se ne restarta sam** — `cloud/app/worker.py`, `cloud/app/main.py` — DONE (v3.16.6)
   Rješenje: in-process supervizor (`worker_supervisor`, spawnan u lifespanu) koji restarta worker task **samo na crash** (`task.exception() is not None`), preko postojećeg `restart_worker_if_dead()`, uz eksponencijalni backoff. Uredan reauth/credential return ostaje netaknut (čeka korisnika na `/auth/login`). Svjesno BEZ container autoheala/self-exita: naivni autoheal bi restart-loopao na reauth-503; zaglavljeni-proces rep ostaje signal-only preko Docker HEALTHCHECK-a (odluka zapisana u CLAUDE.md, Health Monitoring).
 
-- [x] **`restart_playlist` ne provjerava uspjeh PUT-ova** — `cloud/app/spotify_api.py` (`restart_playlist`) — DONE (v3.16.7)
+- [x] **`restart_playlist` ne provjerava uspjeh PUT-ova** — `cloud/app/spotify_api.py` (`restart_playlist`) — DONE (v3.16.7, PR #71)
   Svaki PUT (skok na dummy, shuffle on, skok natrag) sada provjerava status; na grešku logira warning i vraća False. Prvi PUT (skok na dummy playlistu) aborta rano ako padne — playback netaknut. Ako je skok na dummy uspio, skok natrag na originalni kontekst se **uvijek** pokuša (i kad shuffle padne) da korisnik ne ostane zaglavljen na dummy playlisti. Worker call-site (`worker.py`) sada površi neuspjeh u user-facing log ("Playlist restart failed — check the dummy playlist ID in settings.").
 
 ## Nizak prioritet / čišćenje


### PR DESCRIPTION
## Problem

`restart_playlist` (`cloud/app/spotify_api.py`) fired three PUTs — jump to dummy playlist, shuffle on, jump back to original context — and returned `True` unconditionally, ignoring every response status. If `dummy_playlist_id` is invalid (the default is a Spotify editorial playlist, which the API restricts for newer apps), the first PUT 404s and the "restart" silently degraded while looking successful. TODO stavka srednjeg prioriteta iz `docs/todo.md`.

## Fix

- Each PUT's status is now checked (accepting `200/202/204`, konzistentno s `skip_current_track`).
- The **first PUT** (jump to dummy) aborts early on failure — playback is untouched, ništa za vratiti.
- Once playback is on the dummy playlist, the **jump back** to the original context is always attempted even if shuffle fails, so the user is never stranded on the dummy playlist.
- Any failure logs a `logger.warning` (novi modul logger u `spotify_api.py`, kao u `lastfm_api.py`) and the method returns `False`.
- Worker call site (`worker.py`) surfaces the failure to the user-facing log: `"Playlist restart failed — check the dummy playlist ID in settings."`

## Test

- `py -m py_compile` prolazi na sva tri diranata modula.
- Nema browser-observable promjene (worker/API kod) — render/health verifikacija ide pri deployu na VPS.

Version: `v3.16.7-1` (test snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)