### PR TITLE
Chart open: keep Now Playing column at its closed width

### DIFF
--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.8-3"
+APP_VERSION = "v3.16.8"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.8-2"
+APP_VERSION = "v3.16.8-3"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.8-1"
+APP_VERSION = "v3.16.8-2"

--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.7"
+APP_VERSION = "v3.16.8-1"

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -841,21 +841,20 @@ input:focus, select:focus {
 
 .chart-toggle:hover { color: var(--text-secondary); }
 
-@media (min-width: 820px) {
-    .container-wide.chart-open { max-width: 1024px; }
+/* Go side-by-side only when two full-width columns actually fit:
+   608px Now Playing + 16px gap + 608px chart + 32px padding = 1264px.
+   Below that, the chart stacks below (default column layout) at the same
+   width. Either way the Now Playing column keeps its closed 608px width
+   (640px container minus 16px padding each side) and never shrinks. */
+@media (min-width: 1280px) {
+    .container-wide.chart-open { max-width: 1264px; }
     .container-wide.chart-open .dashboard-grid {
         flex-direction: row;
         align-items: flex-start;
         gap: 16px;
     }
-    /* Keep the Now Playing column at its closed width (608px = 640px container
-       minus 16px padding each side) so opening the chart only adds to the right,
-       instead of shrinking the left column. */
     .container-wide.chart-open .dashboard-main { flex: 0 0 608px; }
-    .container-wide.chart-open .dashboard-side {
-        flex: 1 1 auto;
-        min-width: 0;
-    }
+    .container-wide.chart-open .dashboard-side { flex: 0 0 608px; }
     .container-wide.chart-open .dashboard-side .card { margin-bottom: 0; }
 }
 

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -842,13 +842,16 @@ input:focus, select:focus {
 .chart-toggle:hover { color: var(--text-secondary); }
 
 @media (min-width: 820px) {
-    .container-wide.chart-open { max-width: 1040px; }
+    .container-wide.chart-open { max-width: 1024px; }
     .container-wide.chart-open .dashboard-grid {
         flex-direction: row;
         align-items: flex-start;
         gap: 16px;
     }
-    .container-wide.chart-open .dashboard-main { flex: 0 0 380px; }
+    /* Keep the Now Playing column at its closed width (608px = 640px container
+       minus 16px padding each side) so opening the chart only adds to the right,
+       instead of shrinking the left column. */
+    .container-wide.chart-open .dashboard-main { flex: 0 0 608px; }
     .container-wide.chart-open .dashboard-side {
         flex: 1 1 auto;
         min-width: 0;

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -841,20 +841,24 @@ input:focus, select:focus {
 
 .chart-toggle:hover { color: var(--text-secondary); }
 
-/* Go side-by-side only when two full-width columns actually fit:
-   608px Now Playing + 16px gap + 608px chart + 32px padding = 1264px.
-   Below that, the chart stacks below (default column layout) at the same
-   width. Either way the Now Playing column keeps its closed 608px width
-   (640px container minus 16px padding each side) and never shrinks. */
-@media (min-width: 1280px) {
-    .container-wide.chart-open { max-width: 1264px; }
+/* Go side-by-side only when two full-width columns actually fit.
+   On desktop (>=768px) .container has 24px padding, so the closed Now
+   Playing column is 640 - 48 = 592px. Match that exactly so it never
+   changes width: 592px Now Playing + 16px gap + 592px chart + 48px
+   padding = 1248px container. Plus the 88px left margin for the sidebar,
+   the layout needs ~1336px, so gate side-by-side at 1360px. Below that
+   the chart stacks below (default column layout) at the same 592px width.
+   Keep these numbers in sync with .container max-width (640) and the
+   desktop padding (24) if either changes. */
+@media (min-width: 1360px) {
+    .container-wide.chart-open { max-width: 1248px; }
     .container-wide.chart-open .dashboard-grid {
         flex-direction: row;
         align-items: flex-start;
         gap: 16px;
     }
-    .container-wide.chart-open .dashboard-main { flex: 0 0 608px; }
-    .container-wide.chart-open .dashboard-side { flex: 0 0 608px; }
+    .container-wide.chart-open .dashboard-main { flex: 0 0 592px; }
+    .container-wide.chart-open .dashboard-side { flex: 0 0 592px; }
     .container-wide.chart-open .dashboard-side .card { margin-bottom: 0; }
 }
 


### PR DESCRIPTION
## Problem

Opening the artist chart on the dashboard visibly narrows the **Now Playing** column. It should only add the chart to the right (or below on mobile), leaving the left column untouched.

## Cause

In the `≥820px` open-state rules, `.dashboard-main` was pinned to `flex: 0 0 380px`, while the closed column is ~608px wide (640px container − 16px padding each side). So opening the chart shrank the left column from 608px → 380px and let the chart fill the widened container.

## Fix

- `.container-wide.chart-open .dashboard-main` → `flex: 0 0 608px` (matches closed width)
- `.container-wide.chart-open` max-width `1040px` → `1024px`

The chart gets ~368px on the right, which comfortably fits 7 flex-scaled columns (`flex: 1`, `min-width: 0`, `max-width: 64px`) plus the wrapping legend. Mobile (`<820px`) still stacks the chart below — unchanged.

Version bumped to `v3.16.8-1` (test snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)