### PR TITLE
fix: show currently playing track while skipping is paused (v3.16.10)

### DIFF
--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.16.9"
+APP_VERSION = "v3.16.10"

--- a/cloud/app/worker.py
+++ b/cloud/app/worker.py
@@ -144,13 +144,6 @@ async def polling_loop():
             idle_threshold = settings["idle_threshold"]
             idle_poll_interval = settings["idle_poll_interval_seconds"]
 
-            # Manual pause
-            if app_state.skipping_paused:
-                await _log("Skipping is paused.")
-                app_state.current_track = None
-                await app_state.interruptible_sleep(poll_interval)
-                continue
-
             track = await client.get_current_track()
 
             # Nothing playing
@@ -177,6 +170,21 @@ async def polling_loop():
                 await _log("Playback detected — resuming normal polling.")
                 app_state.idle_mode = False
             consecutive_idle = 0
+
+            # Manual pause. Deliberately placed after the fetch so the dashboard
+            # still shows what's playing; only the Last.fm lookup and the skip
+            # decision are suspended. last_checked_track_id is left untouched, so
+            # on resume the current song is treated as unchecked and gets its
+            # normal skip decision.
+            if app_state.skipping_paused:
+                await _log("Skipping is paused.")
+                # A song that started while paused was never checked, so the
+                # previous song's verdict must not stay on the dashboard next
+                # to it. An already-checked song keeps its real verdict.
+                if track["id"] != app_state.last_checked_track_id:
+                    app_state.last_check_message = "Not checked — skipping paused"
+                await app_state.interruptible_sleep(poll_interval)
+                continue
 
             # Same song as last time
             if track["id"] == app_state.last_checked_track_id:


### PR DESCRIPTION
## Problem

Pausing skipping also stopped the dashboard from showing what's playing — it read "Nothing is playing" while a song was actually playing, and **Check Now couldn't help**.

The pause check sat *before* the Spotify fetch in `polling_loop`:

```python
if app_state.skipping_paused:
    await _log("Skipping is paused.")
    app_state.current_track = None   # <- actively wiped
    await app_state.interruptible_sleep(poll_interval)
    continue

track = await client.get_current_track()   # never reached while paused
```

`GET /api/playback` returns `app_state.current_track`, hence "Nothing is playing". Check Now only sets `check_now_event`, which interrupts the sleep and restarts the loop — straight back into the same early branch.

## Fix

Move the pause check *after* the fetch and the idle-mode update. The track is fetched and cached for the dashboard; only the Last.fm lookup and the skip decision stay suspended.

- `last_checked_track_id` is left untouched, so on resume the song is treated as unchecked and gets its normal skip decision.
- `last_check_message` is cleared for a song that started while paused — otherwise the previous song's verdict ("Last heard 3 days ago") would render underneath a song that was never checked.

The existing second pause re-check (right before skipping, for a pause pressed mid-Last.fm-query) is unaffected.

Frontend needed no change: the status badge reads `skipping_paused` independently of the track, and pause already outranks idle in the badge chain — so the dashboard now shows the song *and* the "Skipping Paused" badge. Like / Remove from Playlist / Don't Skip This Song enable themselves while paused, which is correct — they call Spotify directly and never depended on the skip loop.

## Trade-off

A paused worker now costs one Spotify call per poll (previously zero). That's the point of the change, and it's a single-user app.

## Verification

Isolated async test driving one real `polling_loop` iteration with mocked Spotify/Last.fm/DB (settings mock built from the real `CONFIG_DEFAULTS` so it can't drift from the schema) — 10/10:

- paused: `current_track` set, Spotify polled, **no** Last.fm lookup, **no** skip
- paused: stale verdict cleared for an unchecked song; an already-checked song keeps its real verdict
- paused: `last_checked_track_id` untouched
- resumed: Last.fm lookup happens, song within window is skipped, `current_track` set

Not yet deployed — prod is on v3.16.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)