### PR TITLE
feat(genres): Playlist Genres tool - genre mix of a playlist

### DIFF
--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.17.0"
+APP_VERSION = "v3.18.0"

--- a/cloud/app/genre_stats.py
+++ b/cloud/app/genre_stats.py
@@ -1,0 +1,82 @@
+"""
+Playlist genre mix — which genres dominate a playlist.
+
+Pipeline: playlist -> primary artist of each track -> that artist's Spotify
+genres -> tally. Every genre Spotify returns for an artist is counted (the list
+already comes back ordered by relevance, and is rarely longer than five).
+
+Two tallies are produced because they answer different questions:
+  - ``tracks``  — how much of the playlist *plays* as this genre
+  - ``artists`` — how much of the roster *is* this genre
+
+A 40-track prog obsession and 40 one-track pop artists look identical on
+``artists`` and nothing alike on ``tracks``, so neither number alone is the
+answer.
+"""
+
+
+def _tally(artists: dict[str, dict], genres_by_artist: dict[str, list[str]]) -> dict:
+    """Fold artists + their genres into per-genre counts."""
+    genres: dict[str, dict] = {}
+    artists_without_genres = 0
+    tracks_without_genres = 0
+
+    for artist_id, info in artists.items():
+        artist_genres = genres_by_artist.get(artist_id) or []
+        track_count = info["track_count"]
+
+        if not artist_genres:
+            artists_without_genres += 1
+            tracks_without_genres += track_count
+            continue
+
+        for genre in artist_genres:
+            slot = genres.setdefault(genre, {"genre": genre, "artists": 0, "tracks": 0, "top_artists": []})
+            slot["artists"] += 1
+            slot["tracks"] += track_count
+            slot["top_artists"].append((track_count, info["name"]))
+
+    rows = []
+    for slot in genres.values():
+        slot["top_artists"].sort(key=lambda pair: (-pair[0], pair[1].lower()))
+        rows.append(
+            {
+                "genre": slot["genre"],
+                "artists": slot["artists"],
+                "tracks": slot["tracks"],
+                "top_artists": [name for _, name in slot["top_artists"][:3]],
+            }
+        )
+    rows.sort(key=lambda row: (-row["tracks"], -row["artists"], row["genre"]))
+
+    return {
+        "genres": rows,
+        "artists_without_genres": artists_without_genres,
+        "tracks_without_genres": tracks_without_genres,
+    }
+
+
+async def compute_genre_stats(spotify_client, playlist_id: str) -> dict:
+    """Return the genre breakdown of a playlist.
+
+    Raises ``CredentialError`` / ``SpotifyAPIError`` from the client — a failed
+    page must not degrade into a partial tally, which would read as a real
+    result while quietly under-counting whole genres.
+    """
+    playlist = await spotify_client.get_playlist_artist_counts(playlist_id)
+    artists = playlist["artists"]
+
+    genres_by_artist = await spotify_client.get_artists_genres(list(artists.keys())) if artists else {}
+    tally = _tally(artists, genres_by_artist)
+
+    counted_tracks = playlist["total_tracks"] - playlist["tracks_without_artist"]
+
+    return {
+        "total_tracks": playlist["total_tracks"],
+        "counted_tracks": counted_tracks,
+        "tracks_without_artist": playlist["tracks_without_artist"],
+        "artist_count": len(artists),
+        "artists_without_genres": tally["artists_without_genres"],
+        "tracks_without_genres": tally["tracks_without_genres"],
+        "genres": tally["genres"],
+    }

--- a/cloud/app/main.py
+++ b/cloud/app/main.py
@@ -143,7 +143,7 @@ async def service_worker():
     )
 
 # Include routers
-from app.routers import artists, auth, insights, logs, loved_sync, playback, rediscovery, settings
+from app.routers import artists, auth, genres, insights, logs, loved_sync, playback, rediscovery, settings
 
 app.include_router(auth.router)
 app.include_router(playback.router)
@@ -153,6 +153,7 @@ app.include_router(insights.router)
 app.include_router(logs.router)
 app.include_router(rediscovery.router)
 app.include_router(loved_sync.router)
+app.include_router(genres.router)
 
 
 # ── Health check ─────────────────────────────────────────────────
@@ -218,6 +219,13 @@ async def rediscovery_page(request: Request):
     if not _is_authenticated(request):
         return templates.TemplateResponse("login.html", {"request": request, "version": APP_VERSION})
     return templates.TemplateResponse("rediscovery.html", {"request": request, "version": APP_VERSION})
+
+
+@app.get("/genres")
+async def genres_page(request: Request):
+    if not _is_authenticated(request):
+        return templates.TemplateResponse("login.html", {"request": request, "version": APP_VERSION})
+    return templates.TemplateResponse("genres.html", {"request": request, "version": APP_VERSION})
 
 
 @app.get("/sync")

--- a/cloud/app/routers/genres.py
+++ b/cloud/app/routers/genres.py
@@ -1,0 +1,44 @@
+"""
+Playlist genre mix API routes.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.genre_stats import compute_genre_stats
+from app.routers.deps import require_auth
+from app.spotify_api import CredentialError, SpotifyAPIError
+from app.state import app_state
+
+router = APIRouter(prefix="/api/genres", tags=["genres"], dependencies=[Depends(require_auth)])
+
+
+@router.get("/playlists")
+async def list_playlists():
+    """Return the user's Spotify playlists for the dropdown."""
+    client = app_state.spotify_client
+    if not client:
+        raise HTTPException(status_code=503, detail="Spotify client not ready")
+    try:
+        playlists = await client.get_user_playlists()
+    except CredentialError:
+        raise HTTPException(status_code=401, detail="Spotify credentials expired.")
+    except SpotifyAPIError as e:
+        raise HTTPException(status_code=502, detail=f"Could not load playlists from Spotify: {e}")
+    return {"playlists": playlists}
+
+
+@router.get("/stats")
+async def stats(playlist_id: str = ""):
+    """Return the genre breakdown of one playlist."""
+    client = app_state.spotify_client
+    if not client:
+        raise HTTPException(status_code=503, detail="Spotify client not ready")
+    if not playlist_id.strip():
+        raise HTTPException(status_code=400, detail="playlist_id is required.")
+
+    try:
+        return await compute_genre_stats(client, playlist_id.strip())
+    except CredentialError as e:
+        raise HTTPException(status_code=401, detail=str(e))
+    except SpotifyAPIError as e:
+        raise HTTPException(status_code=502, detail=f"Spotify: {e}")

--- a/cloud/app/spotify_api.py
+++ b/cloud/app/spotify_api.py
@@ -473,6 +473,85 @@ class SpotifyClient:
             )
         return {"items": items, "total": data.get("total", 0)}
 
+    async def get_playlist_artist_counts(self, playlist_id: str) -> dict:
+        """Return the primary artist of every track in a playlist, with track counts.
+
+        Returns ``{"artists": {artist_id: {"name", "track_count"}}, "total_tracks",
+        "tracks_without_artist"}``.
+
+        Only the *primary* (first-credited) artist counts, so each track
+        contributes exactly once and featured guests don't inflate the mix.
+
+        Pagination is offset-driven rather than following ``next``: the ``fields``
+        mask below strips ``next`` from the response, so relying on it would end
+        the loop after the first page and silently truncate the scan.
+        """
+        artists: dict[str, dict] = {}
+        total_tracks = 0
+        tracks_without_artist = 0
+        offset = 0
+        playlist_total = 0
+
+        while True:
+            r = await self._get(
+                f"https://api.spotify.com/v1/playlists/{playlist_id}/tracks",
+                params={
+                    "limit": 100,
+                    "offset": offset,
+                    "fields": "total,items(track(id,artists(id,name)))",
+                },
+            )
+            if r is None or r.status_code != 200:
+                raise _spotify_error(r, f"Fetching playlist artists at offset {offset}")
+            data = r.json() or {}
+            playlist_total = data.get("total", 0)
+            items = data.get("items") or []
+            if not items:
+                break
+
+            for entry in items:
+                track = (entry or {}).get("track") or {}
+                total_tracks += 1
+                credited = track.get("artists") or []
+                primary = credited[0] if credited else {}
+                artist_id = (primary or {}).get("id")
+                if not artist_id:
+                    # Local files and podcast episodes carry no artist ID.
+                    tracks_without_artist += 1
+                    continue
+                slot = artists.setdefault(artist_id, {"name": primary.get("name", ""), "track_count": 0})
+                slot["track_count"] += 1
+
+            offset += len(items)
+            if offset >= playlist_total:
+                break
+
+        return {
+            "artists": artists,
+            "total_tracks": total_tracks,
+            "tracks_without_artist": tracks_without_artist,
+        }
+
+    async def get_artists_genres(self, artist_ids: list[str]) -> dict[str, list[str]]:
+        """Return ``{artist_id: [genres]}`` for the given artists (batches of 50).
+
+        An artist Spotify hasn't classified comes back with an empty list — that
+        is a normal, and increasingly common, answer rather than an error.
+        """
+        out: dict[str, list[str]] = {}
+        for i in range(0, len(artist_ids), 50):
+            batch = artist_ids[i : i + 50]
+            r = await self._get("https://api.spotify.com/v1/artists", params={"ids": ",".join(batch)})
+            if r is None or r.status_code != 200:
+                raise _spotify_error(r, f"Fetching artist genres at index {i}")
+            data = r.json() or {}
+            for a in data.get("artists") or []:
+                # Unknown IDs come back as null entries in the array.
+                if not a or not a.get("id"):
+                    continue
+                out[a["id"]] = a.get("genres") or []
+        return out
+
     async def create_playlist(self, name: str, description: str = "", public: bool = False) -> dict | None:
         """Create a new playlist. Returns {id, url} or None."""
         # Need user ID first

--- a/cloud/app/static/css/style.css
+++ b/cloud/app/static/css/style.css
@@ -1157,6 +1157,72 @@ input:focus, select:focus {
     max-width: 340px;
 }
 
+/* ── Playlist Genres ────────────────────────────── */
+
+.genre-toolbar {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 12px;
+}
+
+.genre-sort {
+    display: flex;
+    gap: 6px;
+}
+
+.genre-row {
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border-secondary);
+}
+
+.genre-row:last-child { border-bottom: none; }
+
+.genre-row-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 6px;
+}
+
+.genre-name {
+    font-size: 0.9rem;
+    font-weight: 600;
+    word-break: break-word;
+}
+
+.genre-count {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.genre-bar-track {
+    height: 6px;
+    border-radius: 3px;
+    background: var(--bg-input);
+    overflow: hidden;
+}
+
+.genre-bar-fill {
+    height: 100%;
+    background: var(--accent);
+    border-radius: 3px;
+}
+
+.genre-meta {
+    margin-top: 6px;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 /* ── Responsive ──────────────────────────────────── */
 
 @media (min-width: 768px) {

--- a/cloud/app/static/js/genres.js
+++ b/cloud/app/static/js/genres.js
@@ -1,0 +1,177 @@
+// Playlist Genres — frontend logic
+
+(function () {
+    const select = document.getElementById('playlist-select');
+    const analyzeBtn = document.getElementById('analyze-btn');
+    const loading = document.getElementById('loading');
+    const results = document.getElementById('results');
+    const errorBanner = document.getElementById('error-banner');
+    const errorText = document.getElementById('error-text');
+
+    const statTracks = document.getElementById('stat-tracks');
+    const statArtists = document.getElementById('stat-artists');
+    const statGenres = document.getElementById('stat-genres');
+    const coverageNote = document.getElementById('coverage-note');
+
+    const genreList = document.getElementById('genre-list');
+    const genreEmpty = document.getElementById('genre-empty');
+    const sortChips = document.querySelectorAll('.chip[data-sort]');
+
+    let lastData = null;
+    let sortKey = 'tracks';
+
+    function plural(n, word) {
+        return n + ' ' + word + (n === 1 ? '' : 's');
+    }
+
+    function showError(msg) {
+        errorText.textContent = msg;
+        errorBanner.classList.remove('hidden');
+    }
+
+    function hideError() {
+        errorBanner.classList.add('hidden');
+    }
+
+    // ── Load playlists ──────────────────────────────────
+    (async function loadPlaylists() {
+        try {
+            const r = await fetch('/api/genres/playlists');
+            if (!r.ok) throw new Error('failed');
+            const data = await r.json();
+            const playlists = data.playlists || [];
+
+            select.innerHTML = '<option value="">Select a playlist...</option>';
+            for (const p of playlists) {
+                const opt = document.createElement('option');
+                opt.value = p.id;
+                opt.textContent = p.name + ' (' + p.track_count + ' tracks)';
+                select.appendChild(opt);
+            }
+        } catch (e) {
+            select.innerHTML = '<option value="">Error loading playlists</option>';
+            showError('Could not load your playlists.');
+        }
+    })();
+
+    select.addEventListener('change', function () {
+        analyzeBtn.disabled = !select.value;
+    });
+
+    // ── Analyze ─────────────────────────────────────────
+    analyzeBtn.addEventListener('click', async function () {
+        if (!select.value) return;
+
+        hideError();
+        analyzeBtn.disabled = true;
+        results.classList.add('hidden');
+        loading.classList.remove('hidden');
+
+        try {
+            const r = await fetch('/api/genres/stats?playlist_id=' + encodeURIComponent(select.value));
+            if (!r.ok) {
+                const err = await r.json().catch(function () { return {}; });
+                showError('Analysis failed: ' + (err.detail || r.status));
+                return;
+            }
+            lastData = await r.json();
+            render();
+            results.classList.remove('hidden');
+        } catch (e) {
+            showError('Network error.');
+        } finally {
+            loading.classList.add('hidden');
+            analyzeBtn.disabled = !select.value;
+        }
+    });
+
+    // ── Sort toggle ─────────────────────────────────────
+    sortChips.forEach(function (chip) {
+        chip.addEventListener('click', function () {
+            sortKey = chip.dataset.sort;
+            sortChips.forEach(function (c) { c.classList.toggle('active', c === chip); });
+            if (lastData) render();
+        });
+    });
+
+    // ── Render ──────────────────────────────────────────
+    function render() {
+        const data = lastData;
+
+        statTracks.textContent = data.total_tracks;
+        statArtists.textContent = data.artist_count;
+        statGenres.textContent = data.genres.length;
+
+        const notes = [];
+        if (data.artists_without_genres) {
+            notes.push(
+                data.artists_without_genres + ' of ' + data.artist_count +
+                (data.artist_count === 1 ? ' artist has' : ' artists have') +
+                ' no genre listed on Spotify (' + plural(data.tracks_without_genres, 'track') + ' uncounted).'
+            );
+        }
+        if (data.tracks_without_artist) {
+            notes.push(
+                'Skipped ' + plural(data.tracks_without_artist, 'track') +
+                ' with no artist (local files or podcast episodes).'
+            );
+        }
+        coverageNote.textContent = notes.join(' ');
+
+        const rows = data.genres.slice().sort(function (a, b) {
+            if (sortKey === 'artists') {
+                return b.artists - a.artists || b.tracks - a.tracks || a.genre.localeCompare(b.genre);
+            }
+            return b.tracks - a.tracks || b.artists - a.artists || a.genre.localeCompare(b.genre);
+        });
+
+        genreList.innerHTML = '';
+        if (!rows.length) {
+            genreEmpty.classList.remove('hidden');
+            return;
+        }
+        genreEmpty.classList.add('hidden');
+
+        const max = rows[0][sortKey] || 1;
+
+        for (const row of rows) {
+            const item = document.createElement('div');
+            item.className = 'genre-row';
+
+            const head = document.createElement('div');
+            head.className = 'genre-row-head';
+
+            const name = document.createElement('span');
+            name.className = 'genre-name';
+            name.textContent = row.genre;
+
+            const count = document.createElement('span');
+            count.className = 'genre-count';
+            count.textContent = sortKey === 'artists'
+                ? plural(row.artists, 'artist')
+                : plural(row.tracks, 'track');
+
+            head.appendChild(name);
+            head.appendChild(count);
+
+            const track = document.createElement('div');
+            track.className = 'genre-bar-track';
+            const fill = document.createElement('div');
+            fill.className = 'genre-bar-fill';
+            fill.style.width = Math.max(2, Math.round((row[sortKey] / max) * 100)) + '%';
+            track.appendChild(fill);
+
+            const meta = document.createElement('div');
+            meta.className = 'genre-meta';
+            const other = sortKey === 'artists'
+                ? plural(row.tracks, 'track')
+                : plural(row.artists, 'artist');
+            meta.textContent = other + ' — ' + row.top_artists.join(', ');
+
+            item.appendChild(head);
+            item.appendChild(track);
+            item.appendChild(meta);
+            genreList.appendChild(item);
+        }
+    }
+})();

--- a/cloud/app/templates/genres.html
+++ b/cloud/app/templates/genres.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% block title %}Playlist Genres - Spotify Auto-Skipper{% endblock %}
+{% block content %}
+<div class="container">
+    <h1 class="page-title">Playlist Genres</h1>
+    <p class="text-secondary mb-16">See which genres dominate a playlist. Each track is attributed to its primary artist, and every genre Spotify lists for that artist is counted.</p>
+
+    <div id="error-banner" class="card hidden" style="border-color: var(--color-error);">
+        <div id="error-text"></div>
+    </div>
+
+    <div class="card">
+        <div class="card-title">Playlist</div>
+        <div class="form-group">
+            <select id="playlist-select">
+                <option value="">Loading playlists...</option>
+            </select>
+        </div>
+        <button id="analyze-btn" class="btn btn-accent btn-full" disabled>Analyze</button>
+    </div>
+
+    <div id="loading" class="card hidden">
+        <div class="text-secondary text-center">Reading playlist and fetching artist genres...</div>
+    </div>
+
+    <div id="results" class="hidden">
+        <div class="card">
+            <div class="card-title">Summary</div>
+            <div class="metrics-grid">
+                <div class="metric-card">
+                    <div id="stat-tracks" class="metric-value">-</div>
+                    <div class="metric-label">Tracks</div>
+                </div>
+                <div class="metric-card">
+                    <div id="stat-artists" class="metric-value">-</div>
+                    <div class="metric-label">Artists</div>
+                </div>
+                <div class="metric-card">
+                    <div id="stat-genres" class="metric-value">-</div>
+                    <div class="metric-label">Genres</div>
+                </div>
+            </div>
+            <div id="coverage-note" class="help-text mt-8"></div>
+        </div>
+
+        <div class="card">
+            <div class="genre-toolbar">
+                <div class="card-title">Genre mix</div>
+                <div class="genre-sort">
+                    <button type="button" class="chip active" data-sort="tracks">By tracks</button>
+                    <button type="button" class="chip" data-sort="artists">By artists</button>
+                </div>
+            </div>
+            <div id="genre-list" class="genre-list"></div>
+            <div id="genre-empty" class="text-secondary text-center hidden">No genre data for any artist on this playlist.</div>
+        </div>
+    </div>
+</div>
+
+<script src="/static/js/genres.js?v={{ version }}"></script>
+{% endblock %}

--- a/cloud/app/templates/settings.html
+++ b/cloud/app/templates/settings.html
@@ -129,6 +129,8 @@
             <div class="help-text mt-8">Find songs in a playlist you haven't listened to in a while.</div>
             <a href="/sync" class="btn btn-full mt-16">Loved Sync</a>
             <div class="help-text mt-8">Compare Spotify Liked Songs to Last.fm Loved Tracks.</div>
+            <a href="/genres" class="btn btn-full mt-16">Playlist Genres</a>
+            <div class="help-text mt-8">See which genres dominate a playlist.</div>
         </div>
 
         <div class="card">


### PR DESCRIPTION
New Settings tool at `/genres`: pick a playlist, get its genre breakdown.

## What it does

Playlist tracks -> primary artist of each track -> that artist's Spotify genres -> tally.

Counted **two ways**, because they answer different questions:
- **tracks** — how much of the playlist *plays* as that genre
- **artists** — how much of the roster *is* that genre

A 40-track prog obsession and 40 one-track pop artists look identical on `artists` and nothing alike on `tracks`, so neither number alone is the answer. The toggle switches both the sort and the bars.

Only the primary (first-credited) artist counts, so each track contributes exactly once and featured guests don't inflate the mix.

## Spotify calls added

`get_playlist_artist_counts` paginates on offset/total rather than `next` — the `fields` mask strips `next` from the response, so following it would end the loop after page one and silently truncate the scan. `get_artists_genres` batches ids 50 at a time and tolerates null entries for unknown ids. A failed page raises `SpotifyAPIError` rather than returning a partial tally, which would read as a real result while under-counting whole genres.

## Coverage caveat

Spotify has been shrinking its genre vocabulary since late 2024 and leaves many artists with an empty `genres` array. That is surfaced, not hidden — the summary reports how many artists and tracks fell out of the tally. Local files and podcast episodes carry no artist id and are counted separately.

If coverage turns out poor on real playlists, the fallback is Last.fm `artist.getTopTags` (the API key is already configured for Loved Sync), which would need a stopword filter for tags like "seen live" and "favorites".

## Verification

- Aggregation, pagination and batching unit-tested against a stubbed HTTP layer: 250-track playlist -> 3 pages at offsets 0/100/200; 60 artists -> 2 requests; null artist entries skipped; a failed page raises.
- Page rendered in a browser against stubbed API data (real template, JS and CSS): both sorts, bar scaling, empty playlist, all-unclassified playlist, mobile 375px (no horizontal overflow), no console errors.
- `ruff check cloud/` passes.

Not yet run against real Spotify data — that happens on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)