### PR TITLE
feat(genres): Last.fm as a second genre source, with a tag cache

### DIFF
--- a/cloud/app/__init__.py
+++ b/cloud/app/__init__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "v3.18.0"
+APP_VERSION = "v3.19.0"

--- a/cloud/app/database.py
+++ b/cloud/app/database.py
@@ -3,6 +3,7 @@ SQLite database setup and CRUD helpers.
 All data persists at DATA_DIR/skipper.db (default: /app/data/skipper.db).
 """
 
+import json
 import os
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
@@ -110,6 +111,17 @@ CREATE TABLE IF NOT EXISTS lastfm_auth (
 CREATE TABLE IF NOT EXISTS loved_sync_ignored (
     track_id    TEXT PRIMARY KEY,
     ignored_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Last.fm top tags per artist, keyed by Spotify artist id (that is what the
+-- playlist scan yields). Cache, not a source of truth: Last.fm has no batch
+-- endpoint, so a 600-artist playlist costs 600 requests on a cold run and
+-- roughly zero on a warm one. Rows expire by age, see ARTIST_TAGS_TTL_DAYS.
+CREATE TABLE IF NOT EXISTS artist_tags (
+    artist_id   TEXT PRIMARY KEY,
+    artist_name TEXT NOT NULL DEFAULT '',
+    tags        TEXT NOT NULL DEFAULT '[]',
+    fetched_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX IF NOT EXISTS idx_track_events_timestamp ON track_events(timestamp);
@@ -1202,6 +1214,67 @@ async def remove_loved_sync_ignore(track_id: str):
     db = await get_db()
     try:
         await db.execute("DELETE FROM loved_sync_ignored WHERE track_id = ?", (track_id,))
+        await db.commit()
+    finally:
+        await db.close()
+
+
+ARTIST_TAGS_TTL_DAYS = 30
+
+
+async def get_cached_artist_tags(artist_ids: list[str]) -> dict[str, list[str]]:
+    """Return cached Last.fm tags for the given artists, skipping stale rows.
+
+    Missing and expired entries are simply absent from the result, so the
+    caller treats both the same way: fetch them.
+    """
+    if not artist_ids:
+        return {}
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=ARTIST_TAGS_TTL_DAYS)).isoformat()
+    out: dict[str, list[str]] = {}
+    db = await get_db()
+    try:
+        # Chunked so a large playlist can't blow SQLite's variable limit (999).
+        for i in range(0, len(artist_ids), 500):
+            chunk = artist_ids[i : i + 500]
+            placeholders = ",".join("?" for _ in chunk)
+            cursor = await db.execute(
+                f"SELECT artist_id, tags FROM artist_tags "  # noqa: S608 - placeholders only
+                f"WHERE artist_id IN ({placeholders}) AND fetched_at >= ?",
+                (*chunk, cutoff),
+            )
+            for row in await cursor.fetchall():
+                try:
+                    parsed = json.loads(row["tags"])
+                except (ValueError, TypeError):
+                    continue
+                if isinstance(parsed, list):
+                    out[row["artist_id"]] = [str(t) for t in parsed]
+    finally:
+        await db.close()
+    return out
+
+
+async def save_artist_tags(entries: list[tuple[str, str, list[str]]]):
+    """Upsert (artist_id, artist_name, tags) rows, refreshing fetched_at.
+
+    An empty tag list is a legitimate cached answer — the artist exists but
+    carries no usable genre tags — so it is stored rather than skipped, which
+    keeps the next run from re-querying the same dead ends.
+    """
+    if not entries:
+        return
+    db = await get_db()
+    try:
+        await db.executemany(
+            """INSERT INTO artist_tags (artist_id, artist_name, tags, fetched_at)
+               VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+               ON CONFLICT(artist_id)
+               DO UPDATE SET artist_name = excluded.artist_name,
+                             tags        = excluded.tags,
+                             fetched_at  = CURRENT_TIMESTAMP""",
+            [(aid, name, json.dumps(tags)) for aid, name, tags in entries],
+        )
         await db.commit()
     finally:
         await db.close()

--- a/cloud/app/genre_stats.py
+++ b/cloud/app/genre_stats.py
@@ -1,9 +1,15 @@
 """
 Playlist genre mix — which genres dominate a playlist.
 
-Pipeline: playlist -> primary artist of each track -> that artist's Spotify
-genres -> tally. Every genre Spotify returns for an artist is counted (the list
-already comes back ordered by relevance, and is rarely longer than five).
+Pipeline: playlist -> primary artist of each track -> that artist's genres ->
+tally. Two sources, picked by the user:
+
+  * ``spotify`` — the artist object's ``genres`` array. Batched 50 at a time,
+    so a 600-artist playlist is ~13 requests. Coarse: Spotify classifies a
+    whole scene under one broad label.
+  * ``lastfm``  — crowd-sourced top tags. No batch endpoint exists, so it costs
+    one request per artist, cached in ``artist_tags``. Far more granular, and
+    noisy in a way Spotify's curated list is not — hence the filter below.
 
 Two tallies are produced because they answer different questions:
   - ``tracks``  — how much of the playlist *plays* as this genre
@@ -13,6 +19,81 @@ A 40-track prog obsession and 40 one-track pop artists look identical on
 ``artists`` and nothing alike on ``tracks``, so neither number alone is the
 answer.
 """
+
+import asyncio
+import re
+
+import httpx
+
+from app.database import get_cached_artist_tags, save_artist_tags
+from app.lastfm_api import LASTFM_ERROR, get_artist_top_tags
+
+SOURCE_SPOTIFY = "spotify"
+SOURCE_LASTFM = "lastfm"
+SOURCES = (SOURCE_SPOTIFY, SOURCE_LASTFM)
+
+# ── Last.fm tag filtering ────────────────────────────────────────
+#
+# Last.fm tags are whatever listeners typed, so the top of an artist's list
+# mixes real genres with collection-keeping, sentiment and trivia. These are
+# the non-genre categories that actually show up at high weight; everything
+# else is kept, because guessing at "is this a genre" beyond a deny-list starts
+# discarding real subgenres.
+
+_TAG_NOISE = {
+    # collection / listening habits
+    "seen live", "favorites", "favourites", "favorite", "favourite",
+    "favorite songs", "favourite songs", "favorite bands", "favourite bands",
+    "favorite artists", "favourite artists", "albums i own", "i own it",
+    "vinyl", "cd", "mp3", "spotify", "itunes", "want to see live",
+    "under 2000 listeners", "my music", "music", "check out", "to check out",
+    "recommended", "radio", "playlist",
+    # sentiment
+    "awesome", "amazing", "beautiful", "epic", "masterpiece", "cool", "good",
+    "great", "best", "love", "loved", "love at first listen", "sexy",
+    "brilliant", "genius", "perfect", "favorites songs",
+    # bare nationality — compound tags like "norwegian black metal" are kept,
+    # because there the nationality is part of a real scene name
+    "norwegian", "swedish", "finnish", "german", "french", "polish", "russian",
+    "greek", "italian", "american", "british", "english", "canadian", "usa",
+    "uk", "japanese", "australian", "dutch", "belgian", "portuguese",
+    "spanish", "czech", "ukrainian", "austrian", "swiss", "danish",
+    "icelandic", "brazilian", "chilean", "hungarian", "romanian", "irish",
+    # lineup / vocal descriptors
+    "female vocalists", "female vocalist", "male vocalists", "male vocalist",
+    "female voices", "female fronted", "one man band",
+    # misc non-genre
+    "underground", "obscure", "rare", "old school", "new", "other", "misc",
+}
+
+# Decades and bare years: 90s, 00s, 2010s, 1994
+_TAG_YEAR_RE = re.compile(r"^(19|20)?\d{2}s?$|^\d{4}$")
+
+# Last.fm normalises an artist's top tag to 100. Below this the tail is mostly
+# one-off tags from a single listener.
+TAG_MIN_COUNT = 25
+TAG_MAX_PER_ARTIST = 5
+
+# Last.fm asks for no more than ~5 requests/second.
+LASTFM_CONCURRENCY = 4
+LASTFM_DELAY = 0.2
+
+
+def filter_tags(tags: list[dict]) -> list[str]:
+    """Reduce raw Last.fm tags to genre-ish ones, strongest first."""
+    out: list[str] = []
+    for t in tags:
+        name = (t.get("name") or "").strip().lower()
+        count = t.get("count") or 0
+        if not name or count < TAG_MIN_COUNT:
+            continue
+        if name in _TAG_NOISE or _TAG_YEAR_RE.match(name):
+            continue
+        if name not in out:
+            out.append(name)
+        if len(out) >= TAG_MAX_PER_ARTIST:
+            break
+    return out
 
 
 def _tally(artists: dict[str, dict], genres_by_artist: dict[str, list[str]]) -> dict:
@@ -56,27 +137,103 @@ def _tally(artists: dict[str, dict], genres_by_artist: dict[str, list[str]]) -> 
     }
 
 
-async def compute_genre_stats(spotify_client, playlist_id: str) -> dict:
+async def _lastfm_genres(artists: dict[str, dict], progress=None) -> tuple[dict[str, list[str]], int]:
+    """Return ``({artist_id: [tags]}, lookup_failures)``, using and filling the cache.
+
+    Failures are counted rather than raised: one unreachable artist should not
+    void a 600-artist scan. They are also NOT cached, so the next run retries
+    them, unlike a genuine "Last.fm has no tags for this artist" empty result.
+    """
+    cached = await get_cached_artist_tags(list(artists.keys()))
+    missing = [(aid, info["name"]) for aid, info in artists.items() if aid not in cached]
+
+    result = dict(cached)
+    failures = 0
+    if not missing:
+        if progress:
+            progress(len(artists), len(artists), f"Genres from cache for {len(artists)} artists")
+        return result, failures
+
+    done = len(cached)
+    total = len(artists)
+    if progress:
+        progress(done, total, f"Fetching Last.fm tags... {done}/{total}")
+
+    fetched: list[tuple[str, str, list[str]]] = []
+    sem = asyncio.Semaphore(LASTFM_CONCURRENCY)
+    lock = asyncio.Lock()
+
+    async with httpx.AsyncClient(timeout=20) as http:
+
+        async def one(artist_id: str, name: str):
+            nonlocal done, failures
+            async with sem:
+                raw = await get_artist_top_tags(name, http=http)
+                await asyncio.sleep(LASTFM_DELAY)  # stay under Last.fm's rate limit
+            async with lock:
+                if raw is LASTFM_ERROR:
+                    failures += 1
+                else:
+                    tags = filter_tags(raw)
+                    result[artist_id] = tags
+                    fetched.append((artist_id, name, tags))
+                done += 1
+                if progress:
+                    progress(done, total, f"Fetching Last.fm tags... {done}/{total}")
+
+        await asyncio.gather(*(one(aid, name) for aid, name in missing))
+
+    await save_artist_tags(fetched)
+    return result, failures
+
+
+async def compute_genre_stats(
+    spotify_client,
+    playlist_id: str,
+    source: str = SOURCE_SPOTIFY,
+    progress=None,
+) -> dict:
     """Return the genre breakdown of a playlist.
 
-    Raises ``CredentialError`` / ``SpotifyAPIError`` from the client — a failed
-    page must not degrade into a partial tally, which would read as a real
-    result while quietly under-counting whole genres.
+    ``progress`` is an optional ``callable(current, total, message)`` used to
+    drive the job's progress bar.
+
+    Raises ``CredentialError`` / ``SpotifyAPIError`` from the Spotify client — a
+    failed page must not degrade into a partial tally, which would read as a
+    real result while quietly under-counting whole genres. Last.fm failures are
+    the exception to that: they are per-artist and counted, not fatal.
     """
+    if source not in SOURCES:
+        raise ValueError(f"Unknown genre source: {source}")
+
+    if progress:
+        progress(0, 0, "Reading playlist...")
     playlist = await spotify_client.get_playlist_artist_counts(playlist_id)
     artists = playlist["artists"]
 
-    genres_by_artist = await spotify_client.get_artists_genres(list(artists.keys())) if artists else {}
-    tally = _tally(artists, genres_by_artist)
+    lookup_failures = 0
+    if not artists:
+        genres_by_artist: dict[str, list[str]] = {}
+    elif source == SOURCE_LASTFM:
+        genres_by_artist, lookup_failures = await _lastfm_genres(artists, progress=progress)
+    else:
+        if progress:
+            progress(0, len(artists), f"Fetching Spotify genres for {len(artists)} artists...")
+        genres_by_artist = await spotify_client.get_artists_genres(list(artists.keys()))
+        if progress:
+            progress(len(artists), len(artists), "Tallying...")
 
+    tally = _tally(artists, genres_by_artist)
     counted_tracks = playlist["total_tracks"] - playlist["tracks_without_artist"]
 
     return {
+        "source": source,
         "total_tracks": playlist["total_tracks"],
         "counted_tracks": counted_tracks,
         "tracks_without_artist": playlist["tracks_without_artist"],
         "artist_count": len(artists),
         "artists_without_genres": tally["artists_without_genres"],
         "tracks_without_genres": tally["tracks_without_genres"],
+        "lookup_failures": lookup_failures,
         "genres": tally["genres"],
     }

--- a/cloud/app/lastfm_api.py
+++ b/cloud/app/lastfm_api.py
@@ -330,6 +330,77 @@ async def get_loved_tracks(username: str = "") -> list[dict] | str:
     return results
 
 
+# ── Artist tags (read) ───────────────────────────────────────────
+
+
+async def get_artist_top_tags(artist: str, http: httpx.AsyncClient | None = None) -> list[dict] | str:
+    """Return an artist's top tags as ``[{"name", "count"}]``, ordered by count.
+
+    Returns ``LASTFM_ERROR`` only on a transport/HTTP failure. An artist Last.fm
+    has never heard of comes back as an empty list — a real answer, and the
+    caller must not retry it as if it were a blip.
+
+    ``count`` is Last.fm's relative weight (the top tag is normalised to 100),
+    not a play count. Callers pass an existing client when looping over many
+    artists so the connection pool is reused.
+    """
+    if not artist or not artist.strip():
+        return []
+    api_key = get_lastfm_api_key()
+    if not api_key:
+        return LASTFM_ERROR
+
+    params = {
+        "method": "artist.gettoptags",
+        "artist": artist.strip(),
+        "api_key": api_key,
+        "autocorrect": 1,
+        "format": "json",
+    }
+
+    async def _fetch(client: httpx.AsyncClient):
+        return await client.get(LASTFM_API_URL, params=params)
+
+    try:
+        if http is not None:
+            r = await _fetch(http)
+        else:
+            async with httpx.AsyncClient(timeout=20) as client:
+                r = await _fetch(client)
+    except httpx.RequestError as e:
+        logger.warning("[Last.fm] Network error fetching tags for '%s': %s", artist, e)
+        return LASTFM_ERROR
+
+    if r.status_code != 200:
+        logger.warning("[Last.fm] getTopTags status %d for '%s'", r.status_code, artist)
+        return LASTFM_ERROR
+
+    try:
+        data = r.json() or {}
+    except ValueError:
+        return LASTFM_ERROR
+
+    # error 6 = "artist not found"; anything else is a real failure.
+    if data.get("error"):
+        return [] if data.get("error") == 6 else LASTFM_ERROR
+
+    tags = (data.get("toptags") or {}).get("tag") or []
+    if isinstance(tags, dict):
+        tags = [tags]
+
+    out = []
+    for t in tags:
+        name = (t.get("name") or "").strip()
+        if not name:
+            continue
+        try:
+            count = int(t.get("count") or 0)
+        except (ValueError, TypeError):
+            count = 0
+        out.append({"name": name, "count": count})
+    return out
+
+
 # ── Authenticated session (write) ────────────────────────────────
 
 

--- a/cloud/app/routers/genres.py
+++ b/cloud/app/routers/genres.py
@@ -1,15 +1,34 @@
 """
 Playlist genre mix API routes.
+
+The analysis runs as a background job rather than inside the request. The
+Last.fm source needs one call per artist (no batch endpoint exists), which is
+minutes on a cold cache — far past any sane request timeout. The Spotify source
+is much faster but goes through the same path so there is one flow, one
+progress bar, and no request that quietly grows past its timeout as a playlist
+grows.
 """
 
-from fastapi import APIRouter, Depends, HTTPException
+import asyncio
+import logging
 
-from app.genre_stats import compute_genre_stats
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.genre_stats import SOURCE_SPOTIFY, SOURCES, compute_genre_stats
+from app.observability import report_exception
 from app.routers.deps import require_auth
 from app.spotify_api import CredentialError, SpotifyAPIError
 from app.state import app_state
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/genres", tags=["genres"], dependencies=[Depends(require_auth)])
+
+
+class StartRequest(BaseModel):
+    playlist_id: str
+    source: str = SOURCE_SPOTIFY
 
 
 @router.get("/playlists")
@@ -27,18 +46,79 @@ async def list_playlists():
     return {"playlists": playlists}
 
 
-@router.get("/stats")
-async def stats(playlist_id: str = ""):
-    """Return the genre breakdown of one playlist."""
-    client = app_state.spotify_client
-    if not client:
-        raise HTTPException(status_code=503, detail="Spotify client not ready")
-    if not playlist_id.strip():
-        raise HTTPException(status_code=400, detail="playlist_id is required.")
+async def run_genre_job(playlist_id: str, source: str):
+    """Compute the genre mix and park the result in app_state."""
+
+    def progress(current: int, total: int, message: str):
+        app_state.genres_progress = {"current": current, "total": total, "message": message}
 
     try:
-        return await compute_genre_stats(client, playlist_id.strip())
-    except CredentialError as e:
-        raise HTTPException(status_code=401, detail=str(e))
-    except SpotifyAPIError as e:
-        raise HTTPException(status_code=502, detail=f"Spotify: {e}")
+        result = await compute_genre_stats(
+            app_state.spotify_client, playlist_id, source=source, progress=progress
+        )
+        app_state.genres_result = result
+        app_state.genres_status = "completed"
+        app_state.genres_progress = {
+            "current": result["artist_count"],
+            "total": result["artist_count"],
+            "message": f"Done. {len(result['genres'])} genres across {result['artist_count']} artists.",
+        }
+        logger.info(
+            "[Genres] %s scan done: %d genres, %d artists, %d tracks",
+            source,
+            len(result["genres"]),
+            result["artist_count"],
+            result["total_tracks"],
+        )
+    except asyncio.CancelledError:
+        app_state.genres_status = "idle"
+        app_state.genres_progress = {"message": "Cancelled."}
+        logger.info("[Genres] Job cancelled.")
+        raise
+    except (CredentialError, SpotifyAPIError) as e:
+        app_state.genres_status = "failed"
+        app_state.genres_progress = {"message": f"Spotify: {e}"}
+        logger.warning("[Genres] Job failed: %s", e)
+    except Exception as e:
+        app_state.genres_status = "failed"
+        app_state.genres_progress = {"message": f"Error: {e}"}
+        logger.exception("[Genres] Job failed: %s", e)
+        report_exception(e, component="genres")
+
+
+@router.post("/start")
+async def start_job(body: StartRequest):
+    """Start a genre analysis job."""
+    if app_state.genres_status == "running":
+        raise HTTPException(status_code=409, detail="A genre scan is already running.")
+    if not body.playlist_id.strip():
+        raise HTTPException(status_code=400, detail="playlist_id is required.")
+    if body.source not in SOURCES:
+        raise HTTPException(status_code=400, detail=f"source must be one of {', '.join(SOURCES)}")
+    if not app_state.spotify_client:
+        raise HTTPException(status_code=503, detail="Spotify client not ready")
+
+    app_state.genres_result = None
+    app_state.genres_status = "running"
+    app_state.genres_progress = {"current": 0, "total": 0, "message": "Starting..."}
+    app_state.genres_task = asyncio.create_task(run_genre_job(body.playlist_id.strip(), body.source))
+    return {"ok": True}
+
+
+@router.get("/status")
+async def get_status():
+    """Return the current job status, plus the result once it is done."""
+    return {
+        "status": app_state.genres_status,
+        "progress": app_state.genres_progress,
+        "result": app_state.genres_result,
+    }
+
+
+@router.post("/cancel")
+async def cancel_job():
+    """Cancel a running genre analysis job."""
+    if app_state.genres_task and not app_state.genres_task.done():
+        app_state.genres_task.cancel()
+        return {"ok": True}
+    raise HTTPException(status_code=400, detail="No running job to cancel.")

--- a/cloud/app/state.py
+++ b/cloud/app/state.py
@@ -28,6 +28,12 @@ class AppState:
         # a Spotify /me/tracks/contains call on every 5s poll; a new track is a miss.
         self.liked_status_cache: dict[str, bool] = {}
 
+        # Playlist Genres
+        self.genres_task: asyncio.Task | None = None
+        self.genres_status: str = "idle"  # idle/running/completed/failed
+        self.genres_progress: dict = {}  # {current, total, message}
+        self.genres_result: dict | None = None
+
         # Rediscovery
         self.rediscovery_task: asyncio.Task | None = None
         self.rediscovery_status: str = "idle"  # idle/running/completed/failed

--- a/cloud/app/static/js/genres.js
+++ b/cloud/app/static/js/genres.js
@@ -4,6 +4,10 @@
     const select = document.getElementById('playlist-select');
     const analyzeBtn = document.getElementById('analyze-btn');
     const loading = document.getElementById('loading');
+    const progressMessage = document.getElementById('progress-message');
+    const progressBar = document.getElementById('progress-bar');
+    const progressDetail = document.getElementById('progress-detail');
+    const cancelBtn = document.getElementById('cancel-btn');
     const results = document.getElementById('results');
     const errorBanner = document.getElementById('error-banner');
     const errorText = document.getElementById('error-text');
@@ -16,9 +20,19 @@
     const genreList = document.getElementById('genre-list');
     const genreEmpty = document.getElementById('genre-empty');
     const sortChips = document.querySelectorAll('.chip[data-sort]');
+    const sourceChips = document.querySelectorAll('.chip[data-source]');
+    const sourceHelp = document.getElementById('source-help');
+
+    const SOURCE_HELP = {
+        spotify: 'Fast. Spotify\'s own classification — broad labels, and some artists are unclassified.',
+        lastfm: 'Slow on the first run (one lookup per artist, then cached for 30 days). Crowd-sourced tags — far more granular subgenres.'
+    };
+    const SOURCE_LABEL = {spotify: 'Spotify', lastfm: 'Last.fm'};
 
     let lastData = null;
     let sortKey = 'tracks';
+    let source = 'spotify';
+    let pollTimer = null;
 
     function plural(n, word) {
         return n + ' ' + word + (n === 1 ? '' : 's');
@@ -32,6 +46,8 @@
     function hideError() {
         errorBanner.classList.add('hidden');
     }
+
+    sourceHelp.textContent = SOURCE_HELP[source];
 
     // ── Load playlists ──────────────────────────────────
     (async function loadPlaylists() {
@@ -58,32 +74,113 @@
         analyzeBtn.disabled = !select.value;
     });
 
-    // ── Analyze ─────────────────────────────────────────
+    // ── Source switch ───────────────────────────────────
+    sourceChips.forEach(function (chip) {
+        chip.addEventListener('click', function () {
+            source = chip.dataset.source;
+            sourceChips.forEach(function (c) { c.classList.toggle('active', c === chip); });
+            sourceHelp.textContent = SOURCE_HELP[source];
+        });
+    });
+
+    // ── Start job ───────────────────────────────────────
     analyzeBtn.addEventListener('click', async function () {
         if (!select.value) return;
 
         hideError();
         analyzeBtn.disabled = true;
         results.classList.add('hidden');
+        progressBar.style.width = '0%';
+        progressMessage.textContent = 'Starting...';
+        progressDetail.textContent = '';
+        cancelBtn.disabled = false;
         loading.classList.remove('hidden');
 
         try {
-            const r = await fetch('/api/genres/stats?playlist_id=' + encodeURIComponent(select.value));
+            const r = await fetch('/api/genres/start', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({playlist_id: select.value, source: source}),
+            });
             if (!r.ok) {
                 const err = await r.json().catch(function () { return {}; });
-                showError('Analysis failed: ' + (err.detail || r.status));
+                showError('Could not start: ' + (err.detail || r.status));
+                loading.classList.add('hidden');
+                analyzeBtn.disabled = !select.value;
                 return;
             }
-            lastData = await r.json();
-            render();
-            results.classList.remove('hidden');
         } catch (e) {
             showError('Network error.');
-        } finally {
+            loading.classList.add('hidden');
+            analyzeBtn.disabled = !select.value;
+            return;
+        }
+
+        startPolling();
+    });
+
+    cancelBtn.addEventListener('click', async function () {
+        cancelBtn.disabled = true;
+        try {
+            await fetch('/api/genres/cancel', {method: 'POST'});
+        } catch (e) {
+            // the poll will settle the UI either way
+        }
+    });
+
+    // ── Poll ────────────────────────────────────────────
+    function startPolling() {
+        if (pollTimer) clearInterval(pollTimer);
+        // 1s: the Spotify source often finishes in a couple of ticks
+        pollTimer = setInterval(poll, 1000);
+        poll();
+    }
+
+    function stopPolling() {
+        if (pollTimer) clearInterval(pollTimer);
+        pollTimer = null;
+    }
+
+    async function poll() {
+        let data;
+        try {
+            const r = await fetch('/api/genres/status');
+            if (!r.ok) return;
+            data = await r.json();
+        } catch (e) {
+            return;  // transient — keep polling
+        }
+
+        const progress = data.progress || {};
+        progressMessage.textContent = progress.message || 'Working...';
+        if (progress.total > 0) {
+            const pct = Math.round((progress.current / progress.total) * 100);
+            progressBar.style.width = pct + '%';
+            progressDetail.textContent = progress.current + ' / ' + progress.total + ' artists';
+        } else {
+            progressDetail.textContent = '';
+        }
+
+        if (data.status === 'completed') {
+            stopPolling();
+            loading.classList.add('hidden');
+            analyzeBtn.disabled = !select.value;
+            lastData = data.result;
+            if (lastData) {
+                render();
+                results.classList.remove('hidden');
+            }
+        } else if (data.status === 'failed') {
+            stopPolling();
+            loading.classList.add('hidden');
+            analyzeBtn.disabled = !select.value;
+            showError(progress.message || 'Analysis failed.');
+        } else if (data.status === 'idle') {
+            stopPolling();
             loading.classList.add('hidden');
             analyzeBtn.disabled = !select.value;
         }
-    });
+    }
 
     // ── Sort toggle ─────────────────────────────────────
     sortChips.forEach(function (chip) {
@@ -102,13 +199,16 @@
         statArtists.textContent = data.artist_count;
         statGenres.textContent = data.genres.length;
 
-        const notes = [];
+        const notes = ['Source: ' + (SOURCE_LABEL[data.source] || data.source) + '.'];
         if (data.artists_without_genres) {
             notes.push(
                 data.artists_without_genres + ' of ' + data.artist_count +
                 (data.artist_count === 1 ? ' artist has' : ' artists have') +
-                ' no genre listed on Spotify (' + plural(data.tracks_without_genres, 'track') + ' uncounted).'
+                ' no genre listed (' + plural(data.tracks_without_genres, 'track') + ' uncounted).'
             );
+        }
+        if (data.lookup_failures) {
+            notes.push(plural(data.lookup_failures, 'artist') + ' could not be looked up on Last.fm.');
         }
         if (data.tracks_without_artist) {
             notes.push(
@@ -174,4 +274,20 @@
             genreList.appendChild(item);
         }
     }
+
+    // ── Reattach to a job already running (e.g. after a reload) ──
+    (async function resume() {
+        try {
+            const r = await fetch('/api/genres/status');
+            if (!r.ok) return;
+            const data = await r.json();
+            if (data.status === 'running') {
+                analyzeBtn.disabled = true;
+                loading.classList.remove('hidden');
+                startPolling();
+            }
+        } catch (e) {
+            // ignore
+        }
+    })();
 })();

--- a/cloud/app/templates/genres.html
+++ b/cloud/app/templates/genres.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="container">
     <h1 class="page-title">Playlist Genres</h1>
-    <p class="text-secondary mb-16">See which genres dominate a playlist. Each track is attributed to its primary artist, and every genre Spotify lists for that artist is counted.</p>
+    <p class="text-secondary mb-16">See which genres dominate a playlist. Each track is attributed to its primary artist, and that artist's genres are counted.</p>
 
     <div id="error-banner" class="card hidden" style="border-color: var(--color-error);">
         <div id="error-text"></div>
@@ -16,11 +16,26 @@
                 <option value="">Loading playlists...</option>
             </select>
         </div>
+
+        <div class="form-group">
+            <label>Genre source</label>
+            <div class="filter-chips">
+                <button type="button" class="chip active" data-source="spotify">Spotify</button>
+                <button type="button" class="chip" data-source="lastfm">Last.fm</button>
+            </div>
+            <div id="source-help" class="help-text"></div>
+        </div>
+
         <button id="analyze-btn" class="btn btn-accent btn-full" disabled>Analyze</button>
     </div>
 
     <div id="loading" class="card hidden">
-        <div class="text-secondary text-center">Reading playlist and fetching artist genres...</div>
+        <div id="progress-message" class="text-secondary">Starting...</div>
+        <div class="progress-bar-container mt-8">
+            <div id="progress-bar" class="progress-bar" style="width: 0%"></div>
+        </div>
+        <div id="progress-detail" class="help-text mt-8"></div>
+        <button id="cancel-btn" class="btn btn-full mt-8">Cancel</button>
     </div>
 
     <div id="results" class="hidden">


### PR DESCRIPTION
Adds a source switch to Playlist Genres. Spotify stays the default; Last.fm crowd-sourced tags are the alternative.

## Why

On the real 6139-track library, Spotify called 504 artists "black metal" and stopped there. Last.fm resolves the same roster into atmospheric black metal (283 artists), depressive (99), post- (47), ambient (32) and blackgaze (17) — and surfaces **dungeon synth** as the third-largest genre on the playlist, which Spotify had dissolved into "dark ambient" entirely.

| | Spotify | Last.fm |
|---|---|---|
| distinct genres | 52 | 147 |
| artists with no genre | 57 (9%) | 6 (1%) |
| lookup failures | — | 0 |

## Cost, and what it drove

Last.fm has no batch endpoint: one request per artist, against Spotify's 50. Three consequences:

1. **`artist_tags` cache table**, keyed by Spotify artist id, 30-day TTL. Lookup *failures* are deliberately not cached — unlike a genuine empty tag list, which is a real answer worth remembering — so a network blip can't freeze an artist as genre-less for a month.
2. **The analysis moved to a background job** with progress and cancel, mirroring Rediscovery. Both sources share the path, so there is one flow and one progress bar, and no request that quietly grows past its timeout as a playlist grows.
3. **A deny-list filter for tags.** Last.fm's top tags mix genre with collection-keeping ("seen live", "albums i own"), sentiment, decades and bare nationality. Compound tags like "norwegian black metal" are kept, since there the nationality is part of a real scene name. Filtering beyond a deny-list starts discarding real subgenres.

Per-artist Last.fm failures are counted and surfaced rather than raised — one unreachable artist shouldn't void a 600-artist scan. Spotify pagination failures stay fatal.

## Verification

Unit-tested against a temp DB and stubbed sources:
- **fresh DB** — `artist_tags` created, `init_db` idempotent over 3 runs
- **migrated DB** — built a v3.18.0-era schema with real rows, confirmed the table appears and settings/track_events/track_aliases survive
- cache upsert, empty-answer caching, 30-day TTL expiry, 1200-id chunking past SQLite's 999-variable limit
- tag filter: noise, years, bare nationality, count threshold, per-artist cap, dedupe
- Spotify source produces numbers identical to v3.18.0 (no regression)
- Last.fm source: failures counted not cached; a rerun re-queries only the failed artist

Browser-driven against the real router and job runner: cold run with live progress bar (0% → 90%), warm rerun, source switch, cancel, 409 on concurrent start, 400 on bad source and blank playlist, empty playlist, mid-flight reload reattaching to the running job, mobile 375px, no console errors.

On production against the real library: migration applied to the live DB with all 15177 `track_events` intact; cold Last.fm run 86s, warm 29s, 147 genres, 0 lookup failures — matching the prototype numbers exactly.

`ruff check cloud/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

